### PR TITLE
docs: add large change workflow command

### DIFF
--- a/.claude/commands/large-change.md
+++ b/.claude/commands/large-change.md
@@ -1,0 +1,23 @@
+Execute large or multi-part repository changes using GitHub-style isolation.
+
+Use this workflow when the task involves several fixes/features, security remediation, parallel agents, or anything that should not be pushed directly to `main`.
+
+Steps:
+1. Run `git status --short --branch`, inspect the current branch, and preserve unrelated user changes.
+2. Create or identify one GitHub issue per task/problem.
+3. Create one branch per issue, named with the issue number and short slug, e.g. `35-secure-supabase-auth`.
+4. Use one `git worktree` per branch when work can run in parallel.
+5. Assign each agent/worker to a separate worktree and clear file ownership scope.
+6. Commit frequently inside each worktree, using `.claude/commands/commit.md`:
+   - Conventional Commits
+   - English, concise, 1 line
+   - no secrets
+   - no `Co-Authored-By`
+7. Run relevant checks in each worktree before opening a PR.
+8. Push each branch and open one PR per issue.
+9. Link the PR body to the issue with `Fixes #...` or `Closes #...`.
+10. Let the PR close the issue on merge.
+11. Delete merged branches and remove worktrees.
+12. Do not push directly to `main` unless explicitly requested.
+
+If any step is blocked by GitHub permissions, network, CI, or branch protection, stop and report the blocker instead of collapsing the work into `main`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,14 @@ This repo uses Conventional Commits with Release Please. Prefer `fix:` for small
 
 PRs should include a short summary, linked issue when applicable, manual test notes, and screenshots or screen recordings for UI changes. Mention release or migration risks, especially when changing Codable fields or local JSON persistence.
 
+## Claude-Style Commands
+
+Slash commands map to `.claude/commands/*.md`. For example, `/commit` means read and execute `.claude/commands/commit.md`, and `/large-change` means read and execute `.claude/commands/large-change.md`. Treat text after the slash command as command arguments.
+
+## Large Change Workflow
+
+For large or multi-part changes, use GitHub-style isolation: one issue, branch, worktree, and PR per task. Follow `.claude/commands/large-change.md` and `.claude/commands/commit.md`; for Codex, use the global `large-change-workflow` skill. Do not push directly to `main` unless explicitly requested.
+
 ## Data & Configuration Notes
 
 Local app data is stored under `~/Library/Application Support/Facio/`. When adding Codable fields, provide defaults in `init(from:)` for backward compatibility and update `CodingKeys` plus `encode(to:)`.


### PR DESCRIPTION
## Summary
- Add `.claude/commands/large-change.md` for Claude-style issue/branch/worktree/PR execution.
- Document slash command dispatch in `AGENTS.md`, including `/commit` -> `.claude/commands/commit.md`.
- Point future large work to the global Codex `large-change-workflow` skill.

Fixes #52

## Checks
- `git diff --check HEAD`

## Notes
- Also created local Codex skills outside the repo:
  - `~/.codex/skills/large-change-workflow`
  - `~/.codex/skills/claude-command-dispatch`

Those are local assistant configuration and are not part of this PR.