### PR TITLE
fix(audit): resolve payment and timesheet regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Build
         run: swift build
 
+      - name: Run regression suite
+        run: swift run Facio --run-regressions
+
       - name: Packaging smoke test
         run: |
           VERSION="0.0.0"

--- a/Facio/Diagnostics/RegressionSuite.swift
+++ b/Facio/Diagnostics/RegressionSuite.swift
@@ -53,6 +53,8 @@ enum FacioRegressionSuite {
         RegressionCase(name: "fiat document drops crypto payment configuration", run: fiatDocumentDropsCryptoPaymentConfiguration),
         RegressionCase(name: "bank transfer selects only usable bank accounts", run: bankTransferSelectsOnlyUsableBankAccounts),
         RegressionCase(name: "crypto payment selects only compatible non-blank wallets", run: cryptoPaymentSelectsOnlyCompatibleNonBlankWallets),
+        RegressionCase(name: "payment snapshot freezes exported bank account", run: paymentSnapshotFreezesExportedBankAccount),
+        RegressionCase(name: "paid invoices do not expose Solana Pay request", run: paidInvoicesDoNotExposeSolanaPayRequest),
         RegressionCase(name: "bitcoin payment is crypto but not Solana Pay eligible", run: bitcoinPaymentIsCryptoButNotSolanaPayEligible),
         RegressionCase(name: "document duplication keeps payment and line data without reusing identity", run: documentDuplicationKeepsPaymentAndLineDataWithoutReusingIdentity),
         RegressionCase(name: "sync state tracks pending deletes as dirty data", run: syncStateTracksPendingDeletesAsDirtyData),
@@ -66,6 +68,7 @@ enum FacioRegressionSuite {
         RegressionCase(name: "timesheet custom ranges overlap by client", run: timesheetCustomRangesOverlapByClient),
         RegressionCase(name: "timesheet shared weeks are scoped by client", run: timesheetSharedWeeksAreScopedByClient),
         RegressionCase(name: "timesheet invoice summary applies client snapshot", run: timesheetInvoiceSummaryAppliesClientSnapshot),
+        RegressionCase(name: "timesheet stale context hours are ignored without adjacent owner", run: timesheetStaleContextHoursAreIgnoredWithoutAdjacentOwner),
         RegressionCase(name: "timesheet custom range counts previous weekly context", run: timesheetCustomRangeCountsPreviousWeeklyContext),
         RegressionCase(name: "timesheet invoice daily lines group overtime by week", run: timesheetInvoiceDailyLinesGroupOvertimeByWeek),
         RegressionCase(name: "timesheet invoice daily lines do not split equal rates", run: timesheetInvoiceDailyLinesDoNotSplitEqualRates),
@@ -182,6 +185,7 @@ enum FacioRegressionSuite {
         try expect(document.accountingCurrency == nil, "old payload should not invent accounting currency")
         try expect(document.accountingExchangeRate == nil, "old payload should not invent exchange rate")
         try expect(document.accountingExchangeRateDate == nil, "old payload should not invent exchange rate date")
+        try expect(document.paymentSnapshot == nil, "old payload should not invent payment snapshot")
         try expectEqual(document.clientSiret, "")
         try expectEqual(document.clientTva, "")
         try expectEqual(document.clientApe, "")
@@ -295,6 +299,7 @@ enum FacioRegressionSuite {
         let document = Document(type: .facture, number: "F-003", currency: .usdc, blockchain: .solana)
         document.paymentMode = .crypto
         document.selectedWalletId = blankSolana.id
+        document.ajouterLigne(LineItem(quantite: decimal("1"), prixUnitaire: decimal("10")))
         document.normalizePaymentConfiguration(availableWallets: wallets)
 
         try expect(document.selectedWalletId == nil, "blank selected wallet should be cleared")
@@ -303,6 +308,53 @@ enum FacioRegressionSuite {
         try expectEqual(document.selectedPaymentWalletAddress(from: wallets), "SolAddr")
         try expect(document.isSolanaPayEligible, "USDC on Solana should be Solana Pay eligible")
         try expectEqual(document.solanaPayWalletAddress(from: wallets), "SolAddr")
+    }
+
+    private static func paymentSnapshotFreezesExportedBankAccount() throws {
+        let account = BankAccountEntry(
+            label: "Main",
+            bankName: "Wise",
+            iban: "FR761234",
+            bic: "TRWIBEB1",
+            accountHolder: "Facio"
+        )
+        let company = CompanyInfo()
+        company.bankAccounts = [account]
+
+        let document = Document(type: .facture, currency: .eur)
+        document.paymentMode = .virement
+        document.selectedBankAccountId = account.id
+
+        try expect(document.freezePaymentSnapshot(from: company), "first freeze should create a snapshot")
+
+        company.bankAccounts[0].iban = "FR769999"
+        company.bankAccounts[0].bic = "NEWBIC"
+
+        try expectEqual(document.paymentSnapshot?.iban, "FR761234")
+        try expectEqual(document.paymentSnapshot?.bic, "TRWIBEB1")
+        try expectEqual(document.selectedPaymentBankAccount(from: company.bankAccounts)?.trimmedIBAN, "FR769999")
+    }
+
+    private static func paidInvoicesDoNotExposeSolanaPayRequest() throws {
+        let wallet = WalletEntry(blockchain: .solana, address: "SolAddr", label: "Main")
+        let document = Document(type: .facture, number: "F-PAID", currency: .usdc, blockchain: .solana)
+
+        document.paymentMode = .crypto
+        document.selectedWalletId = wallet.id
+        document.ajouterLigne(LineItem(quantite: decimal("1"), prixUnitaire: decimal("10")))
+        document.normalizePaymentConfiguration(availableWallets: [wallet])
+
+        document.status = .envoyee
+        try expectEqual(document.solanaPayWalletAddress(from: [wallet]), "SolAddr")
+
+        document.status = .payee
+        try expect(document.solanaPayWalletAddress(from: [wallet]) == nil, "paid invoice should not expose payment QR data")
+
+        let zeroAmount = Document(type: .facture, number: "F-ZERO", currency: .usdc, blockchain: .solana)
+        zeroAmount.paymentMode = .crypto
+        zeroAmount.selectedWalletId = wallet.id
+        zeroAmount.normalizePaymentConfiguration(availableWallets: [wallet])
+        try expect(zeroAmount.solanaPayWalletAddress(from: [wallet]) == nil, "zero amount invoice should not expose payment QR data")
     }
 
     private static func bitcoinPaymentIsCryptoButNotSolanaPayEligible() throws {
@@ -466,6 +518,7 @@ enum FacioRegressionSuite {
         try expectEqual(period.clientApe, "")
         try expect(!period.hasClient, "old payload should not be marked with a client")
         try expect(!period.hasGeneratedInvoice, "old payload should not be marked invoiced")
+        try expectEqual(period.invoiceDetailMode, .summary)
         try expectEqual(period.nom, "Mars 2026")
     }
 
@@ -583,6 +636,31 @@ enum FacioRegressionSuite {
         try expectEqual(document.clientTva, "FR96825015001")
         try expectEqual(document.clientApe, "7112P")
         try expectEqual(document.sourceTimesheetId, period.id)
+    }
+
+    private static func timesheetStaleContextHoursAreIgnoredWithoutAdjacentOwner() throws {
+        let company = CompanyInfo()
+        let period = TimesheetPeriod(startDate: date("2026-04-10"), endDate: date("2026-04-10"))
+
+        for dayIndex in 0..<4 {
+            period.semaines[0].jours[dayIndex].heures = decimal("8")
+        }
+        period.semaines[0].jours[4].heures = decimal("8")
+
+        let allocations = TimesheetInvoiceService.dailyAllocations(for: period, adjacentHours: [:])
+        let lineItems = TimesheetInvoiceService.lineItems(
+            for: period,
+            company: company,
+            invoiceLanguage: .fr,
+            detailMode: .summary,
+            adjacentHours: [:]
+        )
+
+        try expectEqual(allocations.count, 1)
+        try expectDecimal(allocations[0].normalHours, equals: "8")
+        try expectDecimal(allocations[0].overtimeHours, equals: "0")
+        try expectEqual(lineItems.count, 1)
+        try expectDecimal(lineItems[0].quantite, equals: "8")
     }
 
     private static func timesheetCustomRangeCountsPreviousWeeklyContext() throws {

--- a/Facio/Localization/L10n+Documents.swift
+++ b/Facio/Localization/L10n+Documents.swift
@@ -47,6 +47,7 @@ extension L10n {
     static func noLines(_ l: AppLanguage) -> String { l == .fr ? "Aucune ligne. Ajoutez-en une ci-dessous." : "No line items. Add one below." }
     static func addEmptyLine(_ l: AppLanguage) -> String { l == .fr ? "Ajouter une ligne vide" : "Add empty line" }
     static func favoriteService(_ l: AppLanguage) -> String { l == .fr ? "Prestation favorite" : "Favorite service" }
+    static func unitShort(_ l: AppLanguage) -> String { l == .fr ? "u" : "unit" }
 
     // Paiement (UI)
     static func paymentBankSection(_ l: AppLanguage) -> String { l == .fr ? "Paiement — Virement bancaire" : "Payment — Bank transfer" }

--- a/Facio/Localization/L10n+Timesheet.swift
+++ b/Facio/Localization/L10n+Timesheet.swift
@@ -64,7 +64,7 @@ extension L10n {
     // Liste periodes
     static func newPeriod(_ l: AppLanguage) -> String { l == .fr ? "Nouvelle periode" : "New period" }
     static func monthlyPeriod(_ l: AppLanguage) -> String { l == .fr ? "Mois" : "Month" }
-    static func customPeriod(_ l: AppLanguage) -> String { l == .fr ? "Custom" : "Custom" }
+    static func customPeriod(_ l: AppLanguage) -> String { l == .fr ? "Personnalisee" : "Custom" }
     static func startDate(_ l: AppLanguage) -> String { l == .fr ? "Debut" : "Start" }
     static func endDate(_ l: AppLanguage) -> String { l == .fr ? "Fin" : "End" }
     static func month(_ l: AppLanguage) -> String { l == .fr ? "Mois" : "Month" }
@@ -87,6 +87,9 @@ extension L10n {
     }
     static func periodOverlapsForClient(_ l: AppLanguage) -> String {
         l == .fr ? "Cette plage chevauche deja une periode pour ce client" : "This range already overlaps a period for this client"
+    }
+    static func cannotSelectClient(_ l: AppLanguage) -> String {
+        l == .fr ? "Client non selectionne" : "Client not selected"
     }
     static func invoiced(_ l: AppLanguage) -> String { l == .fr ? "Facturee" : "Invoiced" }
     static func notInvoiced(_ l: AppLanguage) -> String { l == .fr ? "Non facturee" : "Not invoiced" }

--- a/Facio/Models/Document.swift
+++ b/Facio/Models/Document.swift
@@ -1,6 +1,37 @@
 import Foundation
 import Observation
 
+struct DocumentPaymentSnapshot: Codable, Hashable {
+    var paymentModeRawValue: String = PaymentMode.aucun.rawValue
+    var blockchainRawValue: String?
+    var walletAddress: String = ""
+    var bankName: String = ""
+    var iban: String = ""
+    var bic: String = ""
+    var accountHolder: String = ""
+    var createdAt: Date = Date()
+
+    var paymentMode: PaymentMode {
+        PaymentMode(rawValue: paymentModeRawValue) ?? .aucun
+    }
+
+    var blockchain: Blockchain? {
+        guard let blockchainRawValue else { return nil }
+        return Blockchain(rawValue: blockchainRawValue)
+    }
+
+    var hasUsablePaymentDetails: Bool {
+        switch paymentMode {
+        case .aucun:
+            return false
+        case .crypto:
+            return !walletAddress.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        case .virement:
+            return !iban.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+    }
+}
+
 @Observable
 final class Document: Identifiable, Codable, Hashable {
     var id: UUID = UUID()
@@ -50,6 +81,9 @@ final class Document: Identifiable, Codable, Hashable {
     // Compte bancaire selectionne (quand plusieurs comptes sont configures)
     var selectedBankAccountId: UUID?
 
+    // Copie figee des informations de paiement utilisees pour les exports officiels.
+    var paymentSnapshot: DocumentPaymentSnapshot?
+
     // MARK: - Hashable
 
     static func == (lhs: Document, rhs: Document) -> Bool {
@@ -77,6 +111,7 @@ final class Document: Identifiable, Codable, Hashable {
         set {
             let previousCurrency = decodedCurrency
             currencyRawValue = newValue.rawValue
+            paymentSnapshot = nil
             normalizePaymentConfiguration()
             if previousCurrency != newValue {
                 clearAccountingConversion()
@@ -99,6 +134,7 @@ final class Document: Identifiable, Codable, Hashable {
         }
         set {
             paymentModeRawValue = newValue.rawValue
+            paymentSnapshot = nil
             normalizePaymentConfiguration()
         }
     }
@@ -110,6 +146,7 @@ final class Document: Identifiable, Codable, Hashable {
         }
         set {
             blockchainRawValue = newValue?.rawValue
+            paymentSnapshot = nil
             normalizePaymentConfiguration()
         }
     }
@@ -231,6 +268,10 @@ final class Document: Identifiable, Codable, Hashable {
         paymentMode == .crypto && blockchain == .solana && currency.supportsSolanaPay
     }
 
+    var shouldRenderPaymentRequest: Bool {
+        type == .facture && status != .payee && status != .annulee
+    }
+
     var isOverdue: Bool {
         guard type == .facture, status == .envoyee else { return false }
         let calendar = Calendar.current
@@ -238,8 +279,58 @@ final class Document: Identifiable, Codable, Hashable {
     }
 
     func solanaPayWalletAddress(from wallets: [WalletEntry]) -> String? {
-        guard isSolanaPayEligible else { return nil }
+        guard shouldRenderPaymentRequest, isSolanaPayEligible, totalTTC > 0 else { return nil }
+        if let paymentSnapshot,
+           paymentSnapshot.paymentMode == .crypto,
+           paymentSnapshot.blockchain == .solana {
+            let snapshotAddress = paymentSnapshot.walletAddress.trimmingCharacters(in: .whitespacesAndNewlines)
+            return snapshotAddress.isEmpty ? nil : snapshotAddress
+        }
         return selectedPaymentWalletAddress(from: wallets)
+    }
+
+    @discardableResult
+    func freezePaymentSnapshot(from company: CompanyInfo, at date: Date = Date()) -> Bool {
+        switch paymentMode {
+        case .aucun:
+            if paymentSnapshot == nil { return false }
+            paymentSnapshot = nil
+            return true
+
+        case .crypto:
+            guard let address = selectedPaymentWalletAddress(from: company.wallets) else {
+                if paymentSnapshot == nil { return false }
+                paymentSnapshot = nil
+                return true
+            }
+            let snapshot = DocumentPaymentSnapshot(
+                paymentModeRawValue: PaymentMode.crypto.rawValue,
+                blockchainRawValue: blockchain?.rawValue,
+                walletAddress: address,
+                createdAt: date
+            )
+            guard paymentSnapshot != snapshot else { return false }
+            paymentSnapshot = snapshot
+            return true
+
+        case .virement:
+            guard let account = selectedPaymentBankAccount(from: company.bankAccounts) else {
+                if paymentSnapshot == nil { return false }
+                paymentSnapshot = nil
+                return true
+            }
+            let snapshot = DocumentPaymentSnapshot(
+                paymentModeRawValue: PaymentMode.virement.rawValue,
+                bankName: account.trimmedBankName,
+                iban: account.trimmedIBAN,
+                bic: account.trimmedBIC,
+                accountHolder: account.trimmedAccountHolder,
+                createdAt: date
+            )
+            guard paymentSnapshot != snapshot else { return false }
+            paymentSnapshot = snapshot
+            return true
+        }
     }
 
     // MARK: - Computed totaux
@@ -363,6 +454,7 @@ final class Document: Identifiable, Codable, Hashable {
         copie.paymentModeRawValue = paymentModeRawValue
         copie.selectedWalletId = selectedWalletId
         copie.selectedBankAccountId = selectedBankAccountId
+        copie.paymentSnapshot = nil
         copie.normalizePaymentConfiguration()
 
         for ligne in lignesTriees {
@@ -396,6 +488,7 @@ final class Document: Identifiable, Codable, Hashable {
         case clientSiret, clientTva, clientApe
         case lignes, transactionSignatures, sourceTimesheetId
         case createdAt, updatedAt, notes, selectedWalletId, selectedBankAccountId, langueRawValue
+        case paymentSnapshot
     }
 
     required init(from decoder: Decoder) throws {
@@ -432,6 +525,7 @@ final class Document: Identifiable, Codable, Hashable {
         selectedWalletId = try? container.decode(UUID.self, forKey: .selectedWalletId)
         selectedBankAccountId = try? container.decode(UUID.self, forKey: .selectedBankAccountId)
         langueRawValue = container.decodeOrDefault(String.self, forKey: .langueRawValue, default: AppLanguage.fr.rawValue)
+        paymentSnapshot = try? container.decode(DocumentPaymentSnapshot.self, forKey: .paymentSnapshot)
         normalizePaymentConfiguration()
     }
 
@@ -465,5 +559,6 @@ final class Document: Identifiable, Codable, Hashable {
         try container.encodeIfPresent(selectedWalletId, forKey: .selectedWalletId)
         try container.encodeIfPresent(selectedBankAccountId, forKey: .selectedBankAccountId)
         try container.encode(langueRawValue, forKey: .langueRawValue)
+        try container.encodeIfPresent(paymentSnapshot, forKey: .paymentSnapshot)
     }
 }

--- a/Facio/Models/Timesheet.swift
+++ b/Facio/Models/Timesheet.swift
@@ -15,6 +15,7 @@ final class TimesheetPeriod: Identifiable, Codable, Hashable {
     var updatedAt: Date = Date()
     var invoiceDocumentId: UUID?
     var billedAt: Date?
+    var invoiceDetailModeRawValue: String = TimesheetInvoiceDetailMode.summary.rawValue
     var clientId: UUID?
     var clientNom: String = ""
     var clientAdresse: String = ""
@@ -46,6 +47,11 @@ final class TimesheetPeriod: Identifiable, Codable, Hashable {
     var totalNet: Decimal { totalBrut * coefficientNet }
     var hasGeneratedInvoice: Bool { invoiceDocumentId != nil || billedAt != nil }
     var hasClient: Bool { clientId != nil || !clientNom.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+
+    var invoiceDetailMode: TimesheetInvoiceDetailMode {
+        get { TimesheetInvoiceDetailMode(rawValue: invoiceDetailModeRawValue) ?? .summary }
+        set { invoiceDetailModeRawValue = newValue.rawValue }
+    }
 
     var clientDisplayName: String {
         clientNom.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -403,7 +409,7 @@ final class TimesheetPeriod: Identifiable, Codable, Hashable {
         for day in week.jours {
             let dayHours = isBillableDay(day)
                 ? day.heures
-                : adjacentHours[day.dateString] ?? day.heures
+                : adjacentHours[day.dateString] ?? 0
 
             defer { hoursBeforeDay += dayHours }
             guard isBillableDay(day), dayHours > 0 else { continue }
@@ -461,7 +467,7 @@ final class TimesheetPeriod: Identifiable, Codable, Hashable {
 
     enum CodingKeys: String, CodingKey {
         case id, nom, mois, annee, customStartDateString, customEndDateString, semaines, createdAt, updatedAt
-        case invoiceDocumentId, billedAt
+        case invoiceDocumentId, billedAt, invoiceDetailModeRawValue
         case clientId, clientNom, clientAdresse, clientCodePostal, clientVille
         case clientSiret, clientTva, clientApe
         case tauxNormal, tauxSupplementaire, coefficientNet, seuilHebdo
@@ -479,6 +485,11 @@ final class TimesheetPeriod: Identifiable, Codable, Hashable {
         createdAt = c.decodeOrDefault(Date.self, forKey: .createdAt, default: Date())
         invoiceDocumentId = try? c.decode(UUID.self, forKey: .invoiceDocumentId)
         billedAt = try? c.decode(Date.self, forKey: .billedAt)
+        invoiceDetailModeRawValue = c.decodeOrDefault(
+            String.self,
+            forKey: .invoiceDetailModeRawValue,
+            default: TimesheetInvoiceDetailMode.summary.rawValue
+        )
         clientId = try? c.decode(UUID.self, forKey: .clientId)
         clientNom = c.decodeOrDefault(String.self, forKey: .clientNom, default: "")
         clientAdresse = c.decodeOrDefault(String.self, forKey: .clientAdresse, default: "")
@@ -508,6 +519,7 @@ final class TimesheetPeriod: Identifiable, Codable, Hashable {
         try c.encode(updatedAt, forKey: .updatedAt)
         try c.encodeIfPresent(invoiceDocumentId, forKey: .invoiceDocumentId)
         try c.encodeIfPresent(billedAt, forKey: .billedAt)
+        try c.encode(invoiceDetailModeRawValue, forKey: .invoiceDetailModeRawValue)
         try c.encodeIfPresent(clientId, forKey: .clientId)
         try c.encode(clientNom, forKey: .clientNom)
         try c.encode(clientAdresse, forKey: .clientAdresse)

--- a/Facio/Models/TimesheetWeek.swift
+++ b/Facio/Models/TimesheetWeek.swift
@@ -45,7 +45,7 @@ struct TimesheetWeek: Identifiable, Codable, Hashable {
                 heuresMoisCourant += h
                 moisCourantCommence = true
             } else {
-                h = adjacentHours[jour.dateString] ?? jour.heures
+                h = adjacentHours[jour.dateString] ?? 0
                 if !moisCourantCommence {
                     // Jours d'un autre mois avant le mois courant
                     heuresPrecedentes += h

--- a/Facio/PDF/PDFGenerator.swift
+++ b/Facio/PDF/PDFGenerator.swift
@@ -642,6 +642,10 @@ struct PDFGenerator {
     }
 
     private var shouldRenderPaymentDetails: Bool {
+        if let paymentSnapshot = document.paymentSnapshot {
+            return paymentSnapshot.hasUsablePaymentDetails
+        }
+
         switch document.paymentMode {
         case .aucun:
             return false
@@ -650,6 +654,10 @@ struct PDFGenerator {
         case .virement:
             return document.selectedPaymentBankAccount(from: company.bankAccounts) != nil
         }
+    }
+
+    private var effectivePaymentMode: PaymentMode {
+        document.paymentSnapshot?.paymentMode ?? document.paymentMode
     }
 
     private func trimmedPaymentValue(_ value: String) -> String {
@@ -671,19 +679,36 @@ struct PDFGenerator {
     private func paymentFooterContentHeight(showPayment: Bool) -> CGFloat {
         guard showPayment else { return 0 }
 
-        switch document.paymentMode {
+        switch effectivePaymentMode {
         case .aucun:
             return 0
         case .crypto:
             var height: CGFloat = 12 + 12
-            if let address = document.selectedPaymentWalletAddress(from: company.wallets) {
+            if let address = snapshotWalletAddress ?? document.selectedPaymentWalletAddress(from: company.wallets) {
                 height += 12
                 height += wrappedTextHeight(address, font: PDFLayout.fontSmall, maxWidth: footerRightWidth, lineHeight: footerLineHeight)
             }
             return height
         case .virement:
             var height: CGFloat = 12
-            if let account = document.selectedPaymentBankAccount(from: company.bankAccounts) {
+            if let snapshot = document.paymentSnapshot, snapshot.paymentMode == .virement {
+                let bankName = trimmedPaymentValue(snapshot.bankName)
+                if !bankName.isEmpty {
+                    height += wrappedTextHeight(bankName, font: PDFLayout.fontSmall, maxWidth: footerRightWidth, lineHeight: footerLineHeight)
+                }
+                let iban = trimmedPaymentValue(snapshot.iban)
+                if !iban.isEmpty {
+                    height += wrappedTextHeight("\(L10n.iban(lang)): \(iban)", font: PDFLayout.fontSmall, maxWidth: footerRightWidth, lineHeight: footerLineHeight)
+                }
+                let bic = trimmedPaymentValue(snapshot.bic)
+                if !bic.isEmpty {
+                    height += wrappedTextHeight("\(L10n.bic(lang)): \(bic)", font: PDFLayout.fontSmall, maxWidth: footerRightWidth, lineHeight: footerLineHeight)
+                }
+                let accountHolder = trimmedPaymentValue(snapshot.accountHolder)
+                if !accountHolder.isEmpty {
+                    height += wrappedTextHeight("\(L10n.accountHolder(lang))\(accountHolder)", font: PDFLayout.fontSmall, maxWidth: footerRightWidth, lineHeight: footerLineHeight)
+                }
+            } else if let account = document.selectedPaymentBankAccount(from: company.bankAccounts) {
                 let bankName = trimmedPaymentValue(account.trimmedBankName)
                 if !bankName.isEmpty {
                     height += wrappedTextHeight(bankName, font: PDFLayout.fontSmall, maxWidth: footerRightWidth, lineHeight: footerLineHeight)
@@ -703,6 +728,12 @@ struct PDFGenerator {
             }
             return height
         }
+    }
+
+    private var snapshotWalletAddress: String? {
+        guard let snapshot = document.paymentSnapshot, snapshot.paymentMode == .crypto else { return nil }
+        let address = snapshot.walletAddress.trimmingCharacters(in: .whitespacesAndNewlines)
+        return address.isEmpty ? nil : address
     }
 
     private func wrappedTextHeight(_ text: String, font: NSFont, maxWidth: CGFloat, lineHeight: CGFloat) -> CGFloat {
@@ -768,8 +799,9 @@ struct PDFGenerator {
 
         if !showPayment {
             // Pas de paiement — on n'affiche rien a droite
-        } else if document.paymentMode == .crypto, let walletAddress = document.selectedPaymentWalletAddress(from: company.wallets) {
-            let chainLabel = document.blockchain?.label ?? "Crypto"
+        } else if effectivePaymentMode == .crypto,
+                  let walletAddress = snapshotWalletAddress ?? document.selectedPaymentWalletAddress(from: company.wallets) {
+            let chainLabel = document.paymentSnapshot?.blockchain?.label ?? document.blockchain?.label ?? "Crypto"
             drawText(chainLabel, x: rightX, y: ry, font: PDFLayout.fontSmallBold, color: PDFLayout.textBlack, context: context)
             ry += 12
             drawText(L10n.cryptoTransfer(lang), x: rightX, y: ry, font: PDFLayout.fontSmall, color: PDFLayout.textGray, context: context)
@@ -779,6 +811,33 @@ struct PDFGenerator {
             ry = drawWrappedText(walletAddress, x: rightX, y: ry, font: PDFLayout.fontSmall,
                                  color: PDFLayout.textBlack, context: context, maxWidth: footerRightWidth,
                                  lineHeight: footerLineHeight)
+        } else if let snapshot = document.paymentSnapshot, snapshot.paymentMode == .virement {
+            drawText(L10n.bankTransfer(lang), x: rightX, y: ry, font: PDFLayout.fontSmallBold, color: PDFLayout.textBlack, context: context)
+            ry += 12
+            let bankName = trimmedPaymentValue(snapshot.bankName)
+            if !bankName.isEmpty {
+                ry = drawWrappedText(bankName, x: rightX, y: ry,
+                                     font: PDFLayout.fontSmall, color: PDFLayout.textBlack, context: context,
+                                     maxWidth: footerRightWidth, lineHeight: footerLineHeight)
+            }
+            let iban = trimmedPaymentValue(snapshot.iban)
+            if !iban.isEmpty {
+                ry = drawWrappedText("\(L10n.iban(lang)): \(iban)", x: rightX, y: ry,
+                                     font: PDFLayout.fontSmall, color: PDFLayout.textGray, context: context,
+                                     maxWidth: footerRightWidth, lineHeight: footerLineHeight)
+            }
+            let bic = trimmedPaymentValue(snapshot.bic)
+            if !bic.isEmpty {
+                ry = drawWrappedText("\(L10n.bic(lang)): \(bic)", x: rightX, y: ry,
+                                     font: PDFLayout.fontSmall, color: PDFLayout.textGray, context: context,
+                                     maxWidth: footerRightWidth, lineHeight: footerLineHeight)
+            }
+            let accountHolder = trimmedPaymentValue(snapshot.accountHolder)
+            if !accountHolder.isEmpty {
+                ry = drawWrappedText("\(L10n.accountHolder(lang))\(accountHolder)", x: rightX, y: ry,
+                                     font: PDFLayout.fontSmall, color: PDFLayout.textGray, context: context,
+                                     maxWidth: footerRightWidth, lineHeight: footerLineHeight)
+            }
         } else if let account = document.selectedPaymentBankAccount(from: company.bankAccounts) {
             drawText(L10n.bankTransfer(lang), x: rightX, y: ry, font: PDFLayout.fontSmallBold, color: PDFLayout.textBlack, context: context)
             ry += 12

--- a/Facio/Services/DataStore.swift
+++ b/Facio/Services/DataStore.swift
@@ -382,11 +382,19 @@ final class DataStore: Sendable {
     func deleteTimesheet(_ ts: TimesheetPeriod) {
         guard timesheets.contains(where: { $0.id == ts.id }) else { return }
         let previousTimesheets = timesheets
+        let previousDocuments = documents
+        let now = Date()
         timesheets.removeAll { $0.id == ts.id }
+        _ = syncAllSharedWeeks(updatedAt: now)
+        let documentsChanged = refreshLinkedInvoices(for: timesheets, updatedAt: now)
         if persist(.timesheets, allowBlockedWrite: false) {
             syncService?.markDeleted(ts.id, for: .timesheets)
+            if documentsChanged {
+                saveDocuments()
+            }
         } else {
             timesheets = previousTimesheets
+            documents = previousDocuments
         }
     }
 
@@ -394,7 +402,11 @@ final class DataStore: Sendable {
         let now = Date()
         timesheet.updatedAt = now
         if shouldSyncSharedWeeks {
-            _ = syncSharedWeeks(for: timesheet, updatedAt: now)
+            _ = syncAllSharedWeeks(updatedAt: now)
+        }
+        let refreshCandidates = shouldSyncSharedWeeks ? timesheets : [timesheet]
+        if refreshLinkedInvoices(for: refreshCandidates, updatedAt: now) {
+            saveDocuments()
         }
         saveTimesheets()
     }
@@ -430,7 +442,6 @@ final class DataStore: Sendable {
     }
 
     func canGenerateInvoice(for timesheet: TimesheetPeriod) -> Bool {
-        guard !timesheet.hasGeneratedInvoice, existingInvoice(for: timesheet) == nil else { return false }
         guard timesheet.hasClient else { return false }
         return !invoiceLineItems(for: timesheet, detailMode: .summary).isEmpty
     }
@@ -440,10 +451,15 @@ final class DataStore: Sendable {
         detailMode: TimesheetInvoiceDetailMode
     ) -> Document? {
         if let existingInvoice = existingInvoice(for: timesheet) {
+            timesheet.invoiceDetailMode = detailMode
             markTimesheet(timesheet, invoicedBy: existingInvoice, at: existingInvoice.dateCreation)
+            if refreshLinkedInvoice(for: timesheet, updatedAt: Date()) {
+                saveDocuments()
+            }
+            saveTimesheets()
             return existingInvoice
         }
-        guard !timesheet.hasGeneratedInvoice, timesheet.hasClient else { return nil }
+        guard timesheet.hasClient else { return nil }
 
         let company = companyInfo
         let invoiceLanguage = company.langueParDefaut
@@ -469,6 +485,7 @@ final class DataStore: Sendable {
         document.sourceTimesheetId = timesheet.id
         timesheet.applyClient(to: document)
         document.lignes = lineItems
+        timesheet.invoiceDetailMode = detailMode
 
         addDocument(document)
         markTimesheet(timesheet, invoicedBy: document, at: creationDate)
@@ -516,6 +533,86 @@ final class DataStore: Sendable {
         }
     }
 
+    @discardableResult
+    private func refreshLinkedInvoices(for periods: [TimesheetPeriod], updatedAt now: Date) -> Bool {
+        periods.reduce(false) { didChange, period in
+            refreshLinkedInvoice(for: period, updatedAt: now) || didChange
+        }
+    }
+
+    @discardableResult
+    private func refreshLinkedInvoice(for timesheet: TimesheetPeriod, updatedAt now: Date) -> Bool {
+        guard let invoice = existingInvoice(for: timesheet) else { return false }
+
+        let generatedLineItems = TimesheetInvoiceService.lineItems(
+            for: timesheet,
+            company: companyInfo,
+            invoiceLanguage: invoice.langue,
+            detailMode: timesheet.invoiceDetailMode,
+            adjacentHours: adjacentHours(for: timesheet)
+        )
+        let refreshedLineItems = preservingLineItemIds(generatedLineItems, from: invoice.lignes)
+
+        var changed = false
+        if !lineItemsMatch(invoice.lignes, refreshedLineItems) {
+            invoice.lignes = refreshedLineItems
+            changed = true
+        }
+
+        if invoiceClientSnapshotDiffers(from: timesheet) {
+            timesheet.applyClient(to: invoice)
+            changed = true
+        }
+
+        if invoice.sourceTimesheetId != timesheet.id {
+            invoice.sourceTimesheetId = timesheet.id
+            changed = true
+        }
+
+        if changed {
+            invoice.updatedAt = now
+        }
+        return changed
+    }
+
+    private func preservingLineItemIds(_ newItems: [LineItem], from existingItems: [LineItem]) -> [LineItem] {
+        var items = newItems
+        let existingSorted = existingItems.sorted { $0.ordre < $1.ordre }
+        for index in items.indices where index < existingSorted.count {
+            items[index].id = existingSorted[index].id
+        }
+        return items
+    }
+
+    private func lineItemsMatch(_ lhs: [LineItem], _ rhs: [LineItem]) -> Bool {
+        let lhsSorted = lhs.sorted { $0.ordre < $1.ordre }
+        let rhsSorted = rhs.sorted { $0.ordre < $1.ordre }
+        guard lhsSorted.count == rhsSorted.count else { return false }
+
+        for (left, right) in zip(lhsSorted, rhsSorted) {
+            if left.id != right.id
+                || left.designation != right.designation
+                || left.quantite != right.quantite
+                || left.prixUnitaire != right.prixUnitaire
+                || left.tauxTVA != right.tauxTVA
+                || left.ordre != right.ordre {
+                return false
+            }
+        }
+        return true
+    }
+
+    private func invoiceClientSnapshotDiffers(from timesheet: TimesheetPeriod) -> Bool {
+        guard let invoice = existingInvoice(for: timesheet) else { return false }
+        return invoice.clientNom != timesheet.clientNom
+            || invoice.clientAdresse != timesheet.clientAdresse
+            || invoice.clientCodePostal != timesheet.clientCodePostal
+            || invoice.clientVille != timesheet.clientVille
+            || invoice.clientSiret != timesheet.clientSiret
+            || invoice.clientTva != timesheet.clientTva
+            || invoice.clientApe != timesheet.clientApe
+    }
+
     private func dueDate(from creationDate: Date) -> Date {
         Calendar.current.date(
             byAdding: .day,
@@ -552,8 +649,21 @@ final class DataStore: Sendable {
     /// Pour chaque jour hors-mois dans la période, tire les heures depuis la période adjacente.
     /// Pour chaque jour du mois courant dans une semaine partagée, pousse les heures vers la période adjacente.
     func syncSharedWeeks(for period: TimesheetPeriod) {
-        if syncSharedWeeks(for: period, updatedAt: Date()) {
+        let now = Date()
+        let didSync = syncSharedWeeks(for: period, updatedAt: now)
+        let documentsChanged = refreshLinkedInvoices(for: timesheets, updatedAt: now)
+        if documentsChanged {
+            saveDocuments()
+        }
+        if didSync {
             saveTimesheets()
+        }
+    }
+
+    @discardableResult
+    private func syncAllSharedWeeks(updatedAt now: Date) -> Bool {
+        timesheets.reduce(false) { didChange, period in
+            syncSharedWeeks(for: period, updatedAt: now) || didChange
         }
     }
 
@@ -599,6 +709,10 @@ final class DataStore: Sendable {
                                 }
                             }
                         }
+                    } else if period.semaines[wi].jours[ji].heures != 0 {
+                        period.semaines[wi].jours[ji].heures = 0
+                        period.updatedAt = now
+                        didChange = true
                     }
                 }
             }

--- a/Facio/Services/SyncConfig.swift
+++ b/Facio/Services/SyncConfig.swift
@@ -79,16 +79,22 @@ struct SyncConfig {
 
     /// URL effective (custom ou par defaut)
     static var url: String {
-        useCustomDB && !customURL.isEmpty ? customURL : defaultURL
+        guard useCustomDB else { return defaultURL }
+        return customURL.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     /// API key effective
     static var apiKey: String {
-        useCustomDB && !customAPIKey.isEmpty ? customAPIKey : defaultAPIKey
+        guard useCustomDB else { return defaultAPIKey }
+        return customAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     static var isConfigured: Bool {
-        !url.isEmpty && !apiKey.isEmpty
+        if useCustomDB {
+            return !customURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                && !customAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        return !defaultURL.isEmpty && !defaultAPIKey.isEmpty
     }
 
     static var currentSupabaseConfiguration: SupabaseConfiguration {

--- a/Facio/Services/SyncService.swift
+++ b/Facio/Services/SyncService.swift
@@ -237,6 +237,7 @@ final class SyncService: Sendable {
                 "selected_wallet_id": doc.selectedWalletId?.uuidString ?? NSNull(),
                 "selected_bank_account_id": doc.selectedBankAccountId?.uuidString ?? NSNull(),
                 "langue_raw_value": doc.langueRawValue,
+                "payment_snapshot": paymentSnapshotPayload(doc.paymentSnapshot),
                 "created_at": syncDateString(doc.createdAt),
                 "updated_at": syncDateString(doc.updatedAt),
             ]
@@ -461,6 +462,7 @@ final class SyncService: Sendable {
                 "client_ape": ts.clientApe,
                 "invoice_document_id": ts.invoiceDocumentId?.uuidString ?? NSNull(),
                 "billed_at": ts.billedAt.map(syncDateString) ?? NSNull(),
+                "invoice_detail_mode_raw_value": ts.invoiceDetailModeRawValue,
                 "taux_normal": decimalPayload(ts.tauxNormal),
                 "taux_supplementaire": decimalPayload(ts.tauxSupplementaire),
                 "coefficient_net": decimalPayload(ts.coefficientNet),
@@ -557,6 +559,7 @@ final class SyncService: Sendable {
             doc.selectedWalletId = (json["selected_wallet_id"] as? String).flatMap { UUID(uuidString: $0) }
             doc.selectedBankAccountId = (json["selected_bank_account_id"] as? String).flatMap { UUID(uuidString: $0) }
             doc.langueRawValue = json["langue_raw_value"] as? String ?? "fr"
+            doc.paymentSnapshot = paymentSnapshot(from: json["payment_snapshot"])
             doc.createdAt = parseDate(json["created_at"]) ?? doc.dateCreation
             doc.updatedAt = parseDate(json["updated_at"]) ?? doc.createdAt
 
@@ -734,6 +737,8 @@ final class SyncService: Sendable {
             period.clientApe = json["client_ape"] as? String ?? ""
             period.invoiceDocumentId = (json["invoice_document_id"] as? String).flatMap { UUID(uuidString: $0) }
             period.billedAt = parseDate(json["billed_at"])
+            period.invoiceDetailModeRawValue = json["invoice_detail_mode_raw_value"] as? String
+                ?? TimesheetInvoiceDetailMode.summary.rawValue
             period.tauxNormal = decimalValue(json["taux_normal"], default: 26.39)
             period.tauxSupplementaire = decimalValue(json["taux_supplementaire"], default: 39.59)
             period.coefficientNet = decimalValue(json["coefficient_net"], default: 0.756)
@@ -1053,6 +1058,36 @@ final class SyncService: Sendable {
         NSDecimalNumber(decimal: value).stringValue
     }
 
+    private func paymentSnapshotPayload(_ snapshot: DocumentPaymentSnapshot?) -> Any {
+        guard let snapshot else { return NSNull() }
+        return [
+            "paymentModeRawValue": snapshot.paymentModeRawValue,
+            "blockchainRawValue": snapshot.blockchainRawValue ?? "",
+            "walletAddress": snapshot.walletAddress,
+            "bankName": snapshot.bankName,
+            "iban": snapshot.iban,
+            "bic": snapshot.bic,
+            "accountHolder": snapshot.accountHolder,
+            "createdAt": syncDateString(snapshot.createdAt),
+        ] as [String: Any]
+    }
+
+    private func paymentSnapshot(from value: Any?) -> DocumentPaymentSnapshot? {
+        guard let dictionary = value as? [String: Any] else { return nil }
+        let paymentModeRawValue = dictionary["paymentModeRawValue"] as? String ?? PaymentMode.aucun.rawValue
+        let blockchainRawValue = dictionary["blockchainRawValue"] as? String ?? ""
+        return DocumentPaymentSnapshot(
+            paymentModeRawValue: paymentModeRawValue,
+            blockchainRawValue: blockchainRawValue.isEmpty ? nil : blockchainRawValue,
+            walletAddress: dictionary["walletAddress"] as? String ?? "",
+            bankName: dictionary["bankName"] as? String ?? "",
+            iban: dictionary["iban"] as? String ?? "",
+            bic: dictionary["bic"] as? String ?? "",
+            accountHolder: dictionary["accountHolder"] as? String ?? "",
+            createdAt: parseDate(dictionary["createdAt"]) ?? Date()
+        )
+    }
+
     private func decimalValue(_ value: Any?, default defaultValue: Decimal = 0) -> Decimal {
         if let decimal = value as? Decimal {
             return decimal
@@ -1171,6 +1206,9 @@ final class SyncService: Sendable {
     static let sqlSchema = """
     -- Facio: Schema pour base de donnees custom
     -- Executez ce SQL dans l'editeur SQL de votre projet Supabase
+    -- Migrations non destructives pour bases existantes
+    ALTER TABLE IF EXISTS documents ADD COLUMN IF NOT EXISTS payment_snapshot JSONB;
+    ALTER TABLE IF EXISTS timesheet_periods ADD COLUMN IF NOT EXISTS invoice_detail_mode_raw_value TEXT NOT NULL DEFAULT 'summary';
 
     -- 1. Documents (factures et devis)
     CREATE TABLE documents (
@@ -1199,6 +1237,7 @@ final class SyncService: Sendable {
       selected_wallet_id UUID,
       selected_bank_account_id UUID,
       langue_raw_value TEXT NOT NULL DEFAULT 'fr',
+      payment_snapshot JSONB,
       created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
       updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
     );
@@ -1322,6 +1361,7 @@ final class SyncService: Sendable {
       client_ape TEXT NOT NULL DEFAULT '',
       invoice_document_id UUID,
       billed_at TIMESTAMPTZ,
+      invoice_detail_mode_raw_value TEXT NOT NULL DEFAULT 'summary',
       taux_normal NUMERIC NOT NULL DEFAULT 26.39,
       taux_supplementaire NUMERIC NOT NULL DEFAULT 39.59,
       coefficient_net NUMERIC NOT NULL DEFAULT 0.756,

--- a/Facio/Services/TimesheetInvoiceService.swift
+++ b/Facio/Services/TimesheetInvoiceService.swift
@@ -100,7 +100,7 @@ struct TimesheetInvoiceService {
             for day in week.jours {
                 let dayHours = timesheet.isBillableDay(day)
                     ? day.heures
-                    : adjacentHours[day.dateString] ?? day.heures
+                    : adjacentHours[day.dateString] ?? 0
 
                 defer {
                     hoursBeforeDay += dayHours
@@ -139,7 +139,7 @@ struct TimesheetInvoiceService {
             for day in week.jours {
                 let dayHours = timesheet.isBillableDay(day)
                     ? day.heures
-                    : adjacentHours[day.dateString] ?? day.heures
+                    : adjacentHours[day.dateString] ?? 0
 
                 defer {
                     hoursBeforeDay += dayHours

--- a/Facio/Views/ContentView.swift
+++ b/Facio/Views/ContentView.swift
@@ -50,9 +50,24 @@ struct ContentView: View {
         }
         .navigationSplitViewStyle(.balanced)
         .frame(minWidth: 900, minHeight: 600)
-        .onChange(of: selectedSection) {
-            selectedDocumentId = nil
-            selectedTimesheetId = nil
+        .onChange(of: selectedSection) { _, newSection in
+            switch newSection {
+            case .factures:
+                if selectedDocument?.type != .facture {
+                    selectedDocumentId = nil
+                }
+                selectedTimesheetId = nil
+            case .devis:
+                if selectedDocument?.type != .devis {
+                    selectedDocumentId = nil
+                }
+                selectedTimesheetId = nil
+            case .heures:
+                selectedDocumentId = nil
+            case .clients, .dashboard, .parametres, .none:
+                selectedDocumentId = nil
+                selectedTimesheetId = nil
+            }
         }
     }
 

--- a/Facio/Views/Documents/AddSignatureSheet.swift
+++ b/Facio/Views/Documents/AddSignatureSheet.swift
@@ -11,6 +11,21 @@ struct AddSignatureSheet: View {
     @State private var date = Date()
 
     private var lang: AppLanguage { dataStore.companyInfo.langueParDefaut }
+    private var trimmedSignature: String {
+        signature.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var compatibleBlockchains: [Blockchain] {
+        if let documentBlockchain = document.blockchain {
+            return [documentBlockchain]
+        }
+        let chains = Blockchain.compatibleBlockchains(for: document.currency)
+        return chains.isEmpty ? Blockchain.allCases : chains
+    }
+
+    private var canAddProof: Bool {
+        !trimmedSignature.isEmpty && montant > 0
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -20,9 +35,7 @@ struct AddSignatureSheet: View {
         }
         .frame(minWidth: 500, minHeight: 300)
         .onAppear {
-            if let chain = document.blockchain {
-                selectedBlockchain = chain
-            }
+            selectedBlockchain = document.blockchain ?? compatibleBlockchains.first ?? .solana
             montant = document.totalTTC
         }
     }
@@ -41,7 +54,7 @@ struct AddSignatureSheet: View {
     private var form: some View {
         Form {
             Picker(L10n.blockchain(lang), selection: $selectedBlockchain) {
-                ForEach(Blockchain.allCases) { chain in
+                ForEach(compatibleBlockchains) { chain in
                     Text(chain.label).tag(chain)
                 }
             }
@@ -62,7 +75,7 @@ struct AddSignatureSheet: View {
             Spacer()
             Button(L10n.add(lang)) {
                 let tx = TransactionSignature(
-                    signature: signature,
+                    signature: trimmedSignature,
                     date: date,
                     montant: montant,
                     blockchain: selectedBlockchain
@@ -72,7 +85,7 @@ struct AddSignatureSheet: View {
                 dismiss()
             }
             .keyboardShortcut(.defaultAction)
-            .disabled(signature.isEmpty)
+            .disabled(!canAddProof)
         }
         .padding()
     }

--- a/Facio/Views/Documents/DocumentEditorView.swift
+++ b/Facio/Views/Documents/DocumentEditorView.swift
@@ -29,6 +29,10 @@ struct DocumentEditorView: View {
         dataStore.companyInfo
     }
 
+    private var availablePaymentModes: [PaymentMode] {
+        document.currency.isCrypto ? PaymentMode.allCases : [.aucun, .virement]
+    }
+
     private func scheduleSave() {
         saveTask?.cancel()
         saveTask = Task {
@@ -201,6 +205,9 @@ struct DocumentEditorView: View {
                             get: { document.status },
                             set: { newStatus in
                                 document.status = newStatus
+                                if newStatus == .envoyee {
+                                    _ = document.freezePaymentSnapshot(from: company)
+                                }
                                 prepareAccountingConversionIfNeeded()
                                 saveDocument()
                                 if newStatus == .payee && document.currency.isCrypto
@@ -265,7 +272,7 @@ struct DocumentEditorView: View {
                         get: { document.paymentMode },
                         set: { document.paymentMode = $0; saveDocument() }
                     )) {
-                        ForEach(PaymentMode.allCases) { mode in
+                        ForEach(availablePaymentModes) { mode in
                             Text(mode.label(for: lang)).tag(mode)
                         }
                     }
@@ -508,6 +515,12 @@ struct DocumentEditorView: View {
     }
 
     private func exporterPDF() {
+        if document.paymentSnapshot == nil {
+            if document.freezePaymentSnapshot(from: company) {
+                saveDocument()
+            }
+        }
+
         let pdfData = PDFGenerator(document: document, company: company).generate()
         guard !pdfData.isEmpty else {
             showPDFGenerationAlert = true

--- a/Facio/Views/Documents/DocumentLineItemsSection.swift
+++ b/Facio/Views/Documents/DocumentLineItemsSection.swift
@@ -87,7 +87,7 @@ struct DocumentLineItemsSection: View {
                             HStack {
                                 Text(preset.designation)
                                 Spacer()
-                                Text("\(NSDecimalNumber(decimal: preset.prixUnitaire))€/u")
+                                Text("\(document.currency.formatAccounting(preset.prixUnitaire, lang: company.formatNombre))/\(L10n.unitShort(lang))")
                                     .foregroundStyle(.secondary)
                             }
                         }

--- a/Facio/Views/Documents/DocumentPaymentInfoView.swift
+++ b/Facio/Views/Documents/DocumentPaymentInfoView.swift
@@ -47,6 +47,7 @@ struct DocumentPaymentInfoView: View {
                 },
                 set: {
                     document.selectedBankAccountId = $0
+                    document.paymentSnapshot = nil
                     onSave()
                 }
             )) {
@@ -141,6 +142,7 @@ struct DocumentPaymentInfoView: View {
                 },
                 set: {
                     document.selectedWalletId = $0
+                    document.paymentSnapshot = nil
                     onSave()
                 }
             )) {

--- a/Facio/Views/Documents/DocumentSignaturesSection.swift
+++ b/Facio/Views/Documents/DocumentSignaturesSection.swift
@@ -5,6 +5,7 @@ struct DocumentSignaturesSection: View {
     let lang: AppLanguage
     let onAdd: () -> Void
     let onDelete: (TransactionSignature) -> Void
+    @Environment(DataStore.self) private var dataStore
 
     var body: some View {
         GroupBox(L10n.paymentProofsSection(lang)) {
@@ -29,7 +30,13 @@ struct DocumentSignaturesSection: View {
                     .padding(.vertical, 8)
             } else {
                 ForEach(document.transactionSignatures) { signature in
-                    SignatureRowView(document: document, signature: signature, lang: lang) {
+                    SignatureRowView(
+                        document: document,
+                        signature: signature,
+                        lang: lang,
+                        dateFormat: dataStore.companyInfo.formatDate,
+                        numberFormat: dataStore.companyInfo.formatNombre
+                    ) {
                         onDelete(signature)
                     }
                     Divider()
@@ -43,6 +50,8 @@ private struct SignatureRowView: View {
     let document: Document
     let signature: TransactionSignature
     let lang: AppLanguage
+    let dateFormat: AppLanguage
+    let numberFormat: AppLanguage
     let onDelete: () -> Void
 
     var body: some View {
@@ -59,10 +68,10 @@ private struct SignatureRowView: View {
                         .padding(.vertical, 2)
                         .background(Color.appPrimary.opacity(0.1))
                         .clipShape(Capsule())
-                    Text(signature.date.frenchFormatted)
+                    Text(signature.date.formattedDate(for: dateFormat))
                         .font(.caption2)
                         .foregroundStyle(.secondary)
-                    Text(document.currency.format(signature.montant))
+                    Text(document.currency.formatAccounting(signature.montant, lang: numberFormat))
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                 }

--- a/Facio/Views/Documents/LineItemRowView.swift
+++ b/Facio/Views/Documents/LineItemRowView.swift
@@ -9,6 +9,7 @@ struct LineItemRowView: View {
     @Environment(DataStore.self) private var dataStore
 
     private var lang: AppLanguage { dataStore.companyInfo.langueParDefaut }
+    private var numberFormat: AppLanguage { dataStore.companyInfo.formatNombre }
 
     private static let tvaRates: [Decimal] = [0, 5.5, 10, 20]
 
@@ -45,6 +46,7 @@ struct LineItemRowView: View {
                         }
                     )
                 )
+                .format(numberFormat)
                 .frame(width: 80)
 
                 // Prix unitaire
@@ -55,8 +57,10 @@ struct LineItemRowView: View {
                         set: { newVal in
                             if let i = safeIndex() { document.lignes[i].prixUnitaire = newVal; onUpdate() }
                         }
-                    )
+                    ),
+                    maximumFractionDigits: document.currency.maximumFractionDigits
                 )
+                .format(numberFormat)
                 .frame(width: 110)
 
                 // TVA
@@ -74,7 +78,7 @@ struct LineItemRowView: View {
                 .frame(width: 80)
 
                 // Total (lecture seule)
-                Text(currentLigne.totalLigne.formatted2Decimals)
+                Text(document.currency.formatAccounting(currentLigne.totalLigne, lang: numberFormat))
                     .font(.body.monospacedDigit())
                     .frame(width: 110, alignment: .trailing)
 
@@ -99,6 +103,7 @@ struct DecimalField: View {
     let placeholder: String
     @Binding var value: Decimal
     var maximumFractionDigits: Int = 2
+    var format: AppLanguage = .fr
     @State private var text: String = ""
     @FocusState private var isFocused: Bool
 
@@ -130,12 +135,19 @@ struct DecimalField: View {
             }
     }
 
+    func format(_ format: AppLanguage) -> Self {
+        var copy = self
+        copy.format = format
+        return copy
+    }
+
     private func formatDecimal(_ d: Decimal) -> String {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
+        formatter.locale = Locale(identifier: format == .fr ? "fr_FR" : "en_US")
         formatter.minimumFractionDigits = 0
         formatter.maximumFractionDigits = maximumFractionDigits
-        formatter.decimalSeparator = ","
+        formatter.decimalSeparator = format == .fr ? "," : "."
         formatter.groupingSeparator = ""
         return formatter.string(from: d as NSDecimalNumber) ?? "\(d)"
     }

--- a/Facio/Views/Timesheet/TimesheetEditorView.swift
+++ b/Facio/Views/Timesheet/TimesheetEditorView.swift
@@ -6,6 +6,7 @@ struct TimesheetEditorView: View {
     @State private var hourInputMode: TimesheetHourInputMode = .decimal
     @State private var showClientPicker = false
     @State private var showInvoiceDetailOptions = false
+    @State private var showClientOverlapAlert = false
     @State private var hourFieldFocusRequest: TimeFieldFocusRequest?
     @State private var hourFieldFocusNonce = 0
 
@@ -46,7 +47,10 @@ struct TimesheetEditorView: View {
                     timesheet,
                     clientId: client.id,
                     excluding: timesheet.id
-                ) else { return }
+                ) else {
+                    showClientOverlapAlert = true
+                    return
+                }
                 timesheet.applyClient(client)
                 if let invoice = dataStore.existingInvoice(for: timesheet) {
                     timesheet.applyClient(to: invoice)
@@ -70,6 +74,11 @@ struct TimesheetEditorView: View {
             Button(L10n.cancel(lang), role: .cancel) {}
         } message: {
             Text(L10n.chooseInvoiceDetail(lang))
+        }
+        .alert(L10n.cannotSelectClient(lang), isPresented: $showClientOverlapAlert) {
+            Button(L10n.understood(lang), role: .cancel) {}
+        } message: {
+            Text(L10n.periodOverlapsForClient(lang))
         }
     }
 

--- a/Facio/Views/Timesheet/TimesheetListView.swift
+++ b/Facio/Views/Timesheet/TimesheetListView.swift
@@ -279,8 +279,8 @@ struct TimesheetListView: View {
             ts = TimesheetPeriod(startDate: selectedStartDate, endDate: selectedEndDate, client: client)
         }
 
-        // Copier les taux depuis la derniere periode
-        if let last = timesheets.first {
+        // Copier les taux depuis la derniere periode du meme client.
+        if let last = timesheets.first(where: { $0.clientId == client.id }) {
             ts.tauxNormal = last.tauxNormal
             ts.tauxSupplementaire = last.tauxSupplementaire
             ts.coefficientNet = last.coefficientNet


### PR DESCRIPTION
## Summary
- Keeps generated timesheet invoices in sync when an already invoiced timesheet changes.
- Fixes stale adjacent-week overtime context, client overlap feedback, dashboard navigation selection, payment proof validation, and number/date display polish.
- Adds frozen payment snapshots for exported/sent invoices so PDFs keep the original wallet or bank account, and hides Solana Pay QR requests for paid/cancelled/zero-total invoices.
- Adds sync/schema support for payment snapshots and timesheet invoice detail mode.
- Runs the regression suite in CI.

Fixes #61

## Tests
- `swift build`
- `swift run Facio --run-regressions` (36 passed)

## Notes
- Custom Supabase schemas need the included non-destructive `ALTER TABLE IF EXISTS` lines from the updated schema to persist the new fields remotely.