### PR TITLE
fix(i18n): localize remaining user-facing strings

### DIFF
--- a/Facio/FacioApp.swift
+++ b/Facio/FacioApp.swift
@@ -56,6 +56,8 @@ struct FacioApp: App {
                     Text(L10n.updateAvailableMessage(lang, version: updateService.latestVersion ?? ""))
                 }
                 .onAppear {
+                    authService.language = lang
+                    syncService.language = lang
                     if !UserDefaults.standard.bool(forKey: "facio_has_launched") {
                         showFirstLaunch = true
                     }
@@ -69,6 +71,10 @@ struct FacioApp: App {
                             await syncService.fullSync(dataStore: dataStore)
                         }
                     }
+                }
+                .onChange(of: lang) { _, newLanguage in
+                    authService.language = newLanguage
+                    syncService.language = newLanguage
                 }
                 .onChange(of: networkMonitor.isConnected) { _, isConnected in
                     if isConnected && SyncConfig.isEnabled {

--- a/Facio/Localization/AppLanguage.swift
+++ b/Facio/Localization/AppLanguage.swift
@@ -8,7 +8,7 @@ enum AppLanguage: String, Codable, CaseIterable, Identifiable {
 
     var label: String {
         switch self {
-        case .fr: return "Francais"
+        case .fr: return "Français"
         case .en: return "English"
         }
     }

--- a/Facio/Localization/L10n+Common.swift
+++ b/Facio/Localization/L10n+Common.swift
@@ -45,10 +45,11 @@ extension L10n {
     static func selectSection(_ l: AppLanguage) -> String { l == .fr ? "Sélectionnez une section" : "Select a section" }
 
     // Preview / Export
-    static func preview(_ l: AppLanguage) -> String { l == .fr ? "Apercu" : "Preview" }
+    static func preview(_ l: AppLanguage) -> String { l == .fr ? "Aperçu" : "Preview" }
     static func exportPDF(_ l: AppLanguage) -> String { l == .fr ? "Exporter PDF" : "Export PDF" }
     static func exportDocument(_ l: AppLanguage) -> String { l == .fr ? "Exporter le document" : "Export document" }
     static func chooseSaveLocation(_ l: AppLanguage) -> String { l == .fr ? "Choisissez où sauvegarder le fichier PDF" : "Choose where to save the PDF file" }
+    static func chooseCSVSaveLocation(_ l: AppLanguage) -> String { l == .fr ? "Choisissez où sauvegarder le fichier CSV" : "Choose where to save the CSV file" }
     static func previewTitle(_ l: AppLanguage, number: String) -> String { l == .fr ? "Aperçu — \(number)" : "Preview — \(number)" }
     static func pdfGenerationError(_ l: AppLanguage) -> String { l == .fr ? "Erreur de génération" : "Generation error" }
     static func cannotGeneratePDF(_ l: AppLanguage) -> String { l == .fr ? "Impossible de générer le PDF." : "Could not generate PDF." }

--- a/Facio/Localization/L10n+Documents.swift
+++ b/Facio/Localization/L10n+Documents.swift
@@ -21,6 +21,7 @@ extension L10n {
     static func accountingCurrency(_ l: AppLanguage) -> String { l == .fr ? "Devise comptable" : "Accounting currency" }
     static func exchangeRate(_ l: AppLanguage) -> String { l == .fr ? "Taux de conversion" : "Exchange rate" }
     static func accountingTotal(_ l: AppLanguage) -> String { l == .fr ? "Total comptable" : "Accounting total" }
+    static func exchangeRatePrefix(_ l: AppLanguage, source: String) -> String { "1 \(source) =" }
     static func exchangeRateHint(_ l: AppLanguage, source: String, target: String) -> String {
         l == .fr ? "1 \(source) = ... \(target)" : "1 \(source) = ... \(target)"
     }

--- a/Facio/Localization/L10n+Enums.swift
+++ b/Facio/Localization/L10n+Enums.swift
@@ -10,12 +10,12 @@ extension L10n {
 
     // DocumentStatus
     static func draft(_ l: AppLanguage) -> String { l == .fr ? "Brouillon" : "Draft" }
-    static func sent(_ l: AppLanguage) -> String { l == .fr ? "Envoyee" : "Sent" }
-    static func paid(_ l: AppLanguage) -> String { l == .fr ? "Payee" : "Paid" }
-    static func cancelled(_ l: AppLanguage) -> String { l == .fr ? "Annulee" : "Cancelled" }
+    static func sent(_ l: AppLanguage) -> String { l == .fr ? "Envoyée" : "Sent" }
+    static func paid(_ l: AppLanguage) -> String { l == .fr ? "Payée" : "Paid" }
+    static func cancelled(_ l: AppLanguage) -> String { l == .fr ? "Annulée" : "Cancelled" }
 
     // PaymentMode
     static func paymentNone(_ l: AppLanguage) -> String { l == .fr ? "Aucun" : "None" }
-    static func paymentTransfer(_ l: AppLanguage) -> String { l == .fr ? "Virement" : "Transfer" }
+    static func paymentTransfer(_ l: AppLanguage) -> String { l == .fr ? "Virement" : "Bank transfer" }
     static func paymentCrypto(_ l: AppLanguage) -> String { "Crypto" }
 }

--- a/Facio/Localization/L10n+PDF.swift
+++ b/Facio/Localization/L10n+PDF.swift
@@ -7,12 +7,12 @@ extension L10n {
     // Dates
     static func invoiceDate(_ l: AppLanguage) -> String { l == .fr ? "Date de facture: " : "Invoice date: " }
     static func quoteDate(_ l: AppLanguage) -> String { l == .fr ? "Date du devis: " : "Quote date: " }
-    static func dueDate(_ l: AppLanguage) -> String { l == .fr ? "Echeance: " : "Due date: " }
+    static func dueDate(_ l: AppLanguage) -> String { l == .fr ? "Échéance: " : "Due date: " }
     static func recipient(_ l: AppLanguage) -> String { l == .fr ? "DESTINATAIRE" : "RECIPIENT" }
 
     // Tableau
-    static func designation(_ l: AppLanguage) -> String { l == .fr ? "DESIGNATION" : "DESCRIPTION" }
-    static func quantity(_ l: AppLanguage) -> String { l == .fr ? "QUANTITE" : "QUANTITY" }
+    static func designation(_ l: AppLanguage) -> String { l == .fr ? "DÉSIGNATION" : "DESCRIPTION" }
+    static func quantity(_ l: AppLanguage) -> String { l == .fr ? "QUANTITÉ" : "QUANTITY" }
     static func price(_ l: AppLanguage) -> String { l == .fr ? "PRIX" : "PRICE" }
     static func total(_ l: AppLanguage) -> String { "TOTAL" }
     static func vat(_ l: AppLanguage) -> String { l == .fr ? "TVA" : "VAT" }
@@ -37,4 +37,5 @@ extension L10n {
     static func companyFallback(_ l: AppLanguage) -> String { l == .fr ? "ENTREPRISE" : "COMPANY" }
     static func notesLabel(_ l: AppLanguage) -> String { l == .fr ? "NOTES" : "NOTES" }
     static func defaultPDFName(_ l: AppLanguage) -> String { l == .fr ? "document" : "document" }
+    static func paymentProofVia(_ l: AppLanguage) -> String { l == .fr ? "via" : "via" }
 }

--- a/Facio/Localization/L10n+Services.swift
+++ b/Facio/Localization/L10n+Services.swift
@@ -1,0 +1,165 @@
+import Foundation
+
+// MARK: - Services, persistence, sync and exports
+
+extension L10n {
+
+    // Export CSV
+    static func defaultCSVName(_ l: AppLanguage) -> String { l == .fr ? "temps-suivi" : "time-entries" }
+
+    static func csvHeaders(_ l: AppLanguage) -> [String] {
+        l == .fr
+            ? [
+                "date",
+                "description",
+                "client",
+                "projet",
+                "tâche",
+                "tags",
+                "début",
+                "fin",
+                "durée_brute",
+                "durée_arrondie",
+                "facturable",
+                "taux_horaire",
+                "montant",
+                "devise",
+                "facturé",
+                "numéro_facture",
+            ]
+            : [
+                "date",
+                "description",
+                "client",
+                "project",
+                "task",
+                "tags",
+                "start",
+                "end",
+                "duration_raw",
+                "duration_rounded",
+                "billable",
+                "hourly_rate",
+                "amount",
+                "currency",
+                "invoiced",
+                "invoice_number",
+            ]
+    }
+
+    // Persistence
+    static func storageFolderCreationFailed(_ l: AppLanguage, error: String) -> String {
+        l == .fr ? "Impossible de créer le dossier de stockage: \(error)" :
+        "Could not create the storage folder: \(error)"
+    }
+
+    static func backupUnavailable(_ l: AppLanguage) -> String {
+        l == .fr ? "backup indisponible" : "backup unavailable"
+    }
+
+    static func persistenceReadFailed(_ l: AppLanguage, fileName: String, error: String, backupPath: String) -> String {
+        l == .fr ? "Lecture impossible de \(fileName): \(error). Fichier préservé: \(backupPath)" :
+        "Could not read \(fileName): \(error). Preserved file: \(backupPath)"
+    }
+
+    static func persistenceSaveBlocked(_ l: AppLanguage, fileName: String) -> String {
+        l == .fr ? "Sauvegarde bloquée pour \(fileName): le fichier local n'a pas pu être décodé au chargement." :
+        "Save blocked for \(fileName): the local file could not be decoded during load."
+    }
+
+    static func persistenceSaveFailed(_ l: AppLanguage, fileName: String, error: String) -> String {
+        l == .fr ? "Sauvegarde impossible de \(fileName): \(error)" :
+        "Could not save \(fileName): \(error)"
+    }
+
+    static func persistenceBackupFailed(_ l: AppLanguage, fileName: String, error: String) -> String {
+        l == .fr ? "Backup impossible de \(fileName): \(error)" :
+        "Could not back up \(fileName): \(error)"
+    }
+
+    // Authentication
+    static func authMissingSupabaseConfiguration(_ l: AppLanguage) -> String {
+        l == .fr ? "Configuration Supabase manquante" : "Missing Supabase configuration"
+    }
+
+    static func authSendCodeFailed(_ l: AppLanguage, statusCode: Int) -> String {
+        l == .fr ? "Erreur d'envoi du code (HTTP \(statusCode))" :
+        "Could not send the code (HTTP \(statusCode))"
+    }
+
+    static func authInvalidOrExpiredCode(_ l: AppLanguage) -> String {
+        l == .fr ? "Code invalide ou expiré" : "Invalid or expired code"
+    }
+
+    static func authInvalidSupabaseResponse(_ l: AppLanguage) -> String {
+        l == .fr ? "Réponse Supabase invalide" : "Invalid Supabase response"
+    }
+
+    static func authRefreshSessionFailed(_ l: AppLanguage, statusCode: Int) -> String {
+        l == .fr ? "Erreur de rafraîchissement de session (HTTP \(statusCode))" :
+        "Could not refresh the session (HTTP \(statusCode))"
+    }
+
+    static func authSessionMigrationFailed(_ l: AppLanguage) -> String {
+        l == .fr ? "Erreur de migration de la session" : "Could not migrate the session"
+    }
+
+    static func authSessionSaveFailed(_ l: AppLanguage) -> String {
+        l == .fr ? "Erreur d'enregistrement de la session" : "Could not save the session"
+    }
+
+    static func authInvalidSupabaseURL(_ l: AppLanguage) -> String {
+        l == .fr ? "URL Supabase invalide" : "Invalid Supabase URL"
+    }
+
+    static func authInsecureSupabaseURL(_ l: AppLanguage) -> String {
+        l == .fr ? "URL Supabase non sécurisée" : "Insecure Supabase URL"
+    }
+
+    // Synchronization
+    static func syncLocalReadFailed(_ l: AppLanguage, fileName: String) -> String {
+        l == .fr ? "Lecture locale impossible: \(fileName)" : "Could not read local file: \(fileName)"
+    }
+
+    static func syncPartialLocalDataPending(_ l: AppLanguage) -> String {
+        l == .fr ? "Synchronisation partielle: des données locales restent à envoyer." :
+        "Partial sync: some local data still needs to be uploaded."
+    }
+
+    static func syncPartialLocalSaveFailed(_ l: AppLanguage) -> String {
+        l == .fr ? "Synchronisation partielle: sauvegarde locale impossible." :
+        "Partial sync: local save failed."
+    }
+
+    static func syncHTTPError(_ l: AppLanguage, statusCode: Int) -> String {
+        l == .fr ? "Erreur HTTP \(statusCode)" : "HTTP error \(statusCode)"
+    }
+
+    static func syncRemoteIDsInvalidURL(_ l: AppLanguage, table: String) -> String {
+        l == .fr ? "URL Supabase invalide pour \(table)." : "Invalid Supabase URL for \(table)."
+    }
+
+    static func syncRemoteIDsInvalidResponse(_ l: AppLanguage, table: String) -> String {
+        l == .fr ? "Réponse Supabase invalide pendant la lecture des IDs \(table)." :
+        "Invalid Supabase response while reading \(table) IDs."
+    }
+
+    static func syncRemoteIDsHTTPStatus(_ l: AppLanguage, table: String, statusCode: Int, message: String?) -> String {
+        if let message, !message.isEmpty {
+            return l == .fr ? "Lecture des IDs \(table) impossible: HTTP \(statusCode) - \(message)" :
+                "Could not read \(table) IDs: HTTP \(statusCode) - \(message)"
+        }
+        return l == .fr ? "Lecture des IDs \(table) impossible: HTTP \(statusCode)" :
+            "Could not read \(table) IDs: HTTP \(statusCode)"
+    }
+
+    static func syncRemoteIDsInvalidPayload(_ l: AppLanguage, table: String) -> String {
+        l == .fr ? "Payload Supabase invalide pendant la lecture des IDs \(table)." :
+        "Invalid Supabase payload while reading \(table) IDs."
+    }
+
+    static func syncRemoteIDsRequestFailed(_ l: AppLanguage, table: String, error: String) -> String {
+        l == .fr ? "Lecture des IDs \(table) impossible: \(error)" :
+        "Could not read \(table) IDs: \(error)"
+    }
+}

--- a/Facio/Localization/L10n+Settings.swift
+++ b/Facio/Localization/L10n+Settings.swift
@@ -60,6 +60,10 @@ extension L10n {
     static func identity(_ l: AppLanguage) -> String { l == .fr ? "Identité" : "Identity" }
     static func companyName(_ l: AppLanguage) -> String { l == .fr ? "Nom de l'entreprise" : "Company name" }
     static func postalAddress(_ l: AppLanguage) -> String { l == .fr ? "Adresse postale" : "Postal address" }
+    static func postalCodePlaceholder(_ l: AppLanguage) -> String { l == .fr ? "54000" : "10001" }
+    static func siretPlaceholder(_ l: AppLanguage) -> String { l == .fr ? "000 000 000 00000" : "Company registration number" }
+    static func phonePlaceholder(_ l: AppLanguage) -> String { l == .fr ? "06 00 00 00 00" : "(555) 010-0000" }
+    static func contactEmailPlaceholder(_ l: AppLanguage) -> String { l == .fr ? "contact@entreprise.fr" : "contact@company.com" }
     static func chooseAnotherFile(_ l: AppLanguage) -> String { l == .fr ? "Choisir un autre fichier..." : "Choose another file..." }
     static func deleteLogo(_ l: AppLanguage) -> String { l == .fr ? "Supprimer le logo" : "Delete logo" }
     static func dragImageHere(_ l: AppLanguage) -> String { l == .fr ? "Glissez une image ici" : "Drag an image here" }
@@ -76,6 +80,8 @@ extension L10n {
     static func bankNamePlaceholder(_ l: AppLanguage) -> String { l == .fr ? "Ex: Boursorama, BNP, Revolut..." : "Ex: Chase, Wise, Revolut..." }
     static func accountHolderLabel(_ l: AppLanguage) -> String { l == .fr ? "Titulaire du compte" : "Account holder" }
     static func accountHolderPlaceholder(_ l: AppLanguage) -> String { l == .fr ? "Nom du titulaire" : "Account holder name" }
+    static func ibanPlaceholder(_ l: AppLanguage) -> String { l == .fr ? "FR76 0000 0000 0000 0000 0000 000" : "Bank account number / IBAN" }
+    static func bicPlaceholder(_ l: AppLanguage) -> String { l == .fr ? "BNPAFRPP" : "SWIFT / BIC" }
     static func bankAccountIbanRequired(_ l: AppLanguage) -> String { l == .fr ? "IBAN requis pour utiliser ce compte sur une facture" : "IBAN required before this account can be used on an invoice" }
     static func cryptoWallets(_ l: AppLanguage) -> String { l == .fr ? "Wallets Crypto" : "Crypto wallets" }
     static func noWalletConfiguredShort(_ l: AppLanguage) -> String { l == .fr ? "Aucun wallet configuré" : "No wallet configured" }
@@ -109,23 +115,29 @@ extension L10n {
     static func defaultLanguageHint(_ l: AppLanguage) -> String { l == .fr ? "Langue utilisée pour les nouveaux documents" : "Language used for new documents" }
     static func dateFormat(_ l: AppLanguage) -> String { l == .fr ? "Format de date" : "Date format" }
     static func numberFormat(_ l: AppLanguage) -> String { l == .fr ? "Format des nombres" : "Number format" }
+    static func frenchDateFormatSample(_ l: AppLanguage) -> String { "dd/MM/yyyy (02/04/2026)" }
+    static func englishDateFormatSample(_ l: AppLanguage) -> String { "MM/dd/yyyy (04/02/2026)" }
+    static func frenchNumberFormatSample(_ l: AppLanguage) -> String { "1 234,56 (FR)" }
+    static func englishNumberFormatSample(_ l: AppLanguage) -> String { "1,234.56 (EN)" }
 
     // Synchronisation
     static func cloudSync(_ l: AppLanguage) -> String { l == .fr ? "Synchronisation cloud" : "Cloud sync" }
     static func enableOnlineBackup(_ l: AppLanguage) -> String { l == .fr ? "Activer la sauvegarde en ligne" : "Enable online backup" }
     static func syncDescription(_ l: AppLanguage) -> String {
-        l == .fr ? "Vos donnees sont synchronisees dans le cloud. Creez un compte ou connectez-vous pour activer la sync."
+        l == .fr ? "Vos données sont synchronisées dans le cloud. Créez un compte ou connectez-vous pour activer la sync."
         : "Your data is synced to the cloud. Create an account or sign in to enable sync."
     }
     static func account(_ l: AppLanguage) -> String { l == .fr ? "Compte" : "Account" }
     static func connected(_ l: AppLanguage, email: String) -> String { l == .fr ? "Connecté — \(email)" : "Connected — \(email)" }
     static func signOut(_ l: AppLanguage) -> String { l == .fr ? "Déconnexion" : "Sign out" }
-    static func otpSent(_ l: AppLanguage, email: String) -> String { l == .fr ? "Un code a 6 chiffres a ete envoye a **\(email)**" : "A 6-digit code was sent to **\(email)**" }
-    static func verificationCode(_ l: AppLanguage) -> String { l == .fr ? "Code de verification" : "Verification code" }
+    static func otpSent(_ l: AppLanguage, email: String) -> String { l == .fr ? "Un code à 6 chiffres a été envoyé à **\(email)**" : "A 6-digit code was sent to **\(email)**" }
+    static func verificationCode(_ l: AppLanguage) -> String { l == .fr ? "Code de vérification" : "Verification code" }
+    static func otpCodePlaceholder(_ l: AppLanguage) -> String { l == .fr ? "123456" : "123456" }
     static func verify(_ l: AppLanguage) -> String { l == .fr ? "Vérifier" : "Verify" }
     static func resendCode(_ l: AppLanguage) -> String { l == .fr ? "Renvoyer le code" : "Resend code" }
-    static func verifying(_ l: AppLanguage) -> String { l == .fr ? "Verification..." : "Verifying..." }
+    static func verifying(_ l: AppLanguage) -> String { l == .fr ? "Vérification..." : "Verifying..." }
     static func emailLoginPrompt(_ l: AppLanguage) -> String { l == .fr ? "Entrez votre email pour recevoir un code de connexion." : "Enter your email to receive a login code." }
+    static func emailPlaceholder(_ l: AppLanguage) -> String { l == .fr ? "email@exemple.com" : "email@example.com" }
     static func receiveCode(_ l: AppLanguage) -> String { l == .fr ? "Recevoir un code" : "Receive code" }
     static func sendingCode(_ l: AppLanguage) -> String { l == .fr ? "Envoi du code..." : "Sending code..." }
     static func syncStatus(_ l: AppLanguage) -> String { l == .fr ? "Statut" : "Status" }
@@ -138,7 +150,9 @@ extension L10n {
     static func supabaseURL(_ l: AppLanguage) -> String { "URL Supabase" }
     static func apiKeyAnon(_ l: AppLanguage) -> String { l == .fr ? "Clé API (anon)" : "API key (anon)" }
     static func apiKey(_ l: AppLanguage) -> String { l == .fr ? "Clé API" : "API key" }
-    static func sqlSchema(_ l: AppLanguage) -> String { l == .fr ? "Schema SQL pour votre base" : "SQL schema for your database" }
+    static func supabaseURLPlaceholder(_ l: AppLanguage) -> String { l == .fr ? "https://xxx.supabase.co" : "https://xxx.supabase.co" }
+    static func apiKeyPlaceholder(_ l: AppLanguage) -> String { l == .fr ? "eyJhbG..." : "eyJhbG..." }
+    static func sqlSchema(_ l: AppLanguage) -> String { l == .fr ? "Schéma SQL pour votre base" : "SQL schema for your database" }
     static func copySQL(_ l: AppLanguage) -> String { l == .fr ? "Copier le SQL" : "Copy SQL" }
     static func authenticationError(_ l: AppLanguage) -> String {
         l == .fr ? "Connexion impossible" : "Sign-in issue"
@@ -168,19 +182,19 @@ extension L10n {
     static func resetHelp(_ l: AppLanguage) -> String { l == .fr ? "Supprime toutes les données et remet Facio à zéro" : "Deletes all data and resets Facio" }
     static func uninstall(_ l: AppLanguage) -> String { l == .fr ? "Désinstaller" : "Uninstall" }
     static func uninstallHelp(_ l: AppLanguage) -> String { l == .fr ? "Supprime toutes les données et ferme l'application" : "Deletes all data and closes the application" }
-    static func resetDone(_ l: AppLanguage) -> String { l == .fr ? "Reinitialisation effectuee. Relancez Facio." : "Reset complete. Restart Facio." }
+    static func resetDone(_ l: AppLanguage) -> String { l == .fr ? "Réinitialisation effectuée. Relancez Facio." : "Reset complete. Restart Facio." }
     static func irreversibleWarning(_ l: AppLanguage) -> String {
-        l == .fr ? "Ces actions sont irreversibles. Assurez-vous d'avoir exporte vos documents importants."
+        l == .fr ? "Ces actions sont irréversibles. Assurez-vous d'avoir exporté vos documents importants."
         : "These actions are irreversible. Make sure you have exported your important documents."
     }
     static func resetConfirmTitle(_ l: AppLanguage) -> String { l == .fr ? "Réinitialiser Facio ?" : "Reset Facio?" }
     static func resetConfirmMessage(_ l: AppLanguage) -> String {
-        l == .fr ? "Toutes vos donnees seront supprimees (factures, devis, clients, parametres). Cette action est irreversible."
+        l == .fr ? "Toutes vos données seront supprimées (factures, devis, clients, paramètres). Cette action est irréversible."
         : "All your data will be deleted (invoices, quotes, clients, settings). This action is irreversible."
     }
     static func uninstallConfirmTitle(_ l: AppLanguage) -> String { l == .fr ? "Désinstaller Facio ?" : "Uninstall Facio?" }
     static func uninstallConfirmMessage(_ l: AppLanguage) -> String {
-        l == .fr ? "L'application sera fermee et toutes les donnees locales seront supprimees. Vous devrez supprimer Facio.app manuellement."
+        l == .fr ? "L'application sera fermée et toutes les données locales seront supprimées. Vous devrez supprimer Facio.app manuellement."
         : "The application will be closed and all local data will be deleted. You will need to delete Facio.app manually."
     }
 
@@ -189,9 +203,9 @@ extension L10n {
     static func updateAvailable(_ l: AppLanguage, version: String) -> String { l == .fr ? "Version \(version) disponible" : "Version \(version) available" }
     static func upToDate(_ l: AppLanguage) -> String { l == .fr ? "Vous êtes à jour" : "You're up to date" }
     static func updateCheckUnavailable(_ l: AppLanguage) -> String {
-        l == .fr ? "Statut de mise a jour indisponible" : "Update status unavailable"
+        l == .fr ? "Statut de mise à jour indisponible" : "Update status unavailable"
     }
     static func updateCheckFailed(_ l: AppLanguage) -> String {
-        l == .fr ? "Impossible de verifier les mises a jour" : "Could not check for updates"
+        l == .fr ? "Impossible de vérifier les mises à jour" : "Could not check for updates"
     }
 }

--- a/Facio/Localization/L10n+TimeHub.swift
+++ b/Facio/Localization/L10n+TimeHub.swift
@@ -21,13 +21,13 @@ extension L10n {
     static func thisMonth(_ l: AppLanguage) -> String { l == .fr ? "Ce mois" : "This month" }
     static func billableTime(_ l: AppLanguage) -> String { l == .fr ? "Temps facturable" : "Billable time" }
     static func nonBillableTime(_ l: AppLanguage) -> String { l == .fr ? "Temps non facturable" : "Non-billable time" }
-    static func uninvoicedTime(_ l: AppLanguage) -> String { l == .fr ? "Temps non facture" : "Uninvoiced time" }
+    static func uninvoicedTime(_ l: AppLanguage) -> String { l == .fr ? "Temps non facturé" : "Uninvoiced time" }
     static func uninvoicedEntries(_ l: AppLanguage) -> String { l == .fr ? "Entrées non facturées" : "Uninvoiced entries" }
     static func activeTasks(_ l: AppLanguage) -> String { l == .fr ? "Tâches en cours" : "Active tasks" }
     static func byClient(_ l: AppLanguage) -> String { l == .fr ? "Par client" : "By client" }
     static func byProject(_ l: AppLanguage) -> String { l == .fr ? "Par projet" : "By project" }
-    static func toInvoice(_ l: AppLanguage) -> String { l == .fr ? "A facturer" : "To invoice" }
-    static func recentActivity(_ l: AppLanguage) -> String { l == .fr ? "Activite recente" : "Recent activity" }
+    static func toInvoice(_ l: AppLanguage) -> String { l == .fr ? "À facturer" : "To invoice" }
+    static func recentActivity(_ l: AppLanguage) -> String { l == .fr ? "Activité récente" : "Recent activity" }
     static func todayTimeline(_ l: AppLanguage) -> String { l == .fr ? "Aujourd'hui" : "Today" }
     static func openLogToday(_ l: AppLanguage) -> String { l == .fr ? "Voir le journal" : "Open log" }
     static func openCalendarToday(_ l: AppLanguage) -> String { l == .fr ? "Voir le calendrier" : "Open calendar" }
@@ -54,7 +54,7 @@ extension L10n {
         l == .fr ? "Aucune entrée sur cette période." : "No entries in this period."
     }
     static func trackedTime(_ l: AppLanguage) -> String { l == .fr ? "Temps suivi" : "Tracked time" }
-    static func estimated(_ l: AppLanguage) -> String { l == .fr ? "Estime" : "Estimated" }
+    static func estimated(_ l: AppLanguage) -> String { l == .fr ? "Estimé" : "Estimated" }
     static func weekView(_ l: AppLanguage) -> String { l == .fr ? "Semaine" : "Week" }
     static func monthView(_ l: AppLanguage) -> String { l == .fr ? "Mois" : "Month" }
     static func dailyTotal(_ l: AppLanguage) -> String { l == .fr ? "Total jour" : "Daily total" }

--- a/Facio/Localization/L10n+Timesheet.swift
+++ b/Facio/Localization/L10n+Timesheet.swift
@@ -25,7 +25,7 @@ extension L10n {
     static func normalHoursShort(_ l: AppLanguage, value: String) -> String { l == .fr ? "N: \(value)h" : "N: \(value)h" }
     static func overtimeHoursShort(_ l: AppLanguage, value: String) -> String { l == .fr ? "S: +\(value)h" : "OT: +\(value)h" }
     static func normalCost(_ l: AppLanguage) -> String { l == .fr ? "Coût normal" : "Normal cost" }
-    static func overtimeCost(_ l: AppLanguage) -> String { l == .fr ? "Cout sup." : "Overtime cost" }
+    static func overtimeCost(_ l: AppLanguage) -> String { l == .fr ? "Coût sup." : "Overtime cost" }
     static func grossTotal(_ l: AppLanguage) -> String { l == .fr ? "Total brut" : "Gross total" }
     static func netTotal(_ l: AppLanguage) -> String { l == .fr ? "Total net" : "Net total" }
 

--- a/Facio/Localization/L10n.swift
+++ b/Facio/Localization/L10n.swift
@@ -10,5 +10,6 @@ import Foundation
 /// - L10n+Clients     — gestion clients
 /// - L10n+Enums       — labels des enums
 /// - L10n+Sidebar     — navigation laterale
-/// - L10n+Settings    — tous les onglets parametres
+/// - L10n+Settings    — tous les onglets paramètres
+/// - L10n+Services    — persistence, sync, auth et exports
 struct L10n {}

--- a/Facio/Models/Enums.swift
+++ b/Facio/Models/Enums.swift
@@ -8,15 +8,13 @@ enum PaymentMode: String, Codable, CaseIterable, Identifiable {
     case crypto = "Crypto"
 
     var id: String { rawValue }
-    var label: String { rawValue }
+    var label: String { label(for: .fr) }
 
     func label(for lang: AppLanguage) -> String {
-        switch (self, lang) {
-        case (.aucun, .fr): return "Aucun"
-        case (.aucun, .en): return "None"
-        case (.virement, .fr): return "Virement"
-        case (.virement, .en): return "Bank transfer"
-        case (.crypto, _): return "Crypto"
+        switch self {
+        case .aucun: return L10n.paymentNone(lang)
+        case .virement: return L10n.paymentTransfer(lang)
+        case .crypto: return L10n.paymentCrypto(lang)
         }
     }
 }
@@ -29,22 +27,17 @@ enum DocumentType: String, Codable, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 
-    var label: String { rawValue }
+    var label: String { label(for: .fr) }
 
     func label(for lang: AppLanguage) -> String {
-        switch (self, lang) {
-        case (.facture, .fr): return "Facture"
-        case (.facture, .en): return "Invoice"
-        case (.devis, .fr): return "Devis"
-        case (.devis, .en): return "Quote"
+        switch self {
+        case .facture: return L10n.invoice(lang)
+        case .devis: return L10n.quote(lang)
         }
     }
 
     var prefix: String {
-        switch self {
-        case .facture: return "Facture"
-        case .devis: return "Devis"
-        }
+        prefix(for: .fr)
     }
 
     func prefix(for lang: AppLanguage) -> String {
@@ -62,18 +55,14 @@ enum DocumentStatus: String, Codable, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 
-    var label: String { rawValue }
+    var label: String { label(for: .fr) }
 
     func label(for lang: AppLanguage) -> String {
-        switch (self, lang) {
-        case (.brouillon, .fr): return "Brouillon"
-        case (.brouillon, .en): return "Draft"
-        case (.envoyee, .fr): return "Envoyée"
-        case (.envoyee, .en): return "Sent"
-        case (.payee, .fr): return "Payée"
-        case (.payee, .en): return "Paid"
-        case (.annulee, .fr): return "Annulée"
-        case (.annulee, .en): return "Cancelled"
+        switch self {
+        case .brouillon: return L10n.draft(lang)
+        case .envoyee: return L10n.sent(lang)
+        case .payee: return L10n.paid(lang)
+        case .annulee: return L10n.cancelled(lang)
         }
     }
 

--- a/Facio/Models/JourSemaine.swift
+++ b/Facio/Models/JourSemaine.swift
@@ -8,27 +8,11 @@ enum JourSemaine: Int, Codable, CaseIterable, Identifiable {
     var id: Int { rawValue }
 
     var label: String {
-        switch self {
-        case .lundi: return "Lundi"
-        case .mardi: return "Mardi"
-        case .mercredi: return "Mercredi"
-        case .jeudi: return "Jeudi"
-        case .vendredi: return "Vendredi"
-        case .samedi: return "Samedi"
-        case .dimanche: return "Dimanche"
-        }
+        label(for: .fr)
     }
 
     var shortLabel: String {
-        switch self {
-        case .lundi: return "Lun"
-        case .mardi: return "Mar"
-        case .mercredi: return "Mer"
-        case .jeudi: return "Jeu"
-        case .vendredi: return "Ven"
-        case .samedi: return "Sam"
-        case .dimanche: return "Dim"
-        }
+        shortLabel(for: .fr)
     }
 
     func label(for lang: AppLanguage) -> String {

--- a/Facio/Models/TimesheetWeek.swift
+++ b/Facio/Models/TimesheetWeek.swift
@@ -70,7 +70,7 @@ struct TimesheetWeek: Identifiable, Codable, Hashable {
 
     /// Label : "26 fev - 02 mar"
     var label: String {
-        guard let first = jours.first, let last = jours.last else { return "Semaine \(numero)" }
+        guard let first = jours.first, let last = jours.last else { return L10n.week(.fr, number: numero) }
         let f = DateFormatter()
         f.dateFormat = "dd MMM"
         f.locale = Locale(identifier: "fr_FR")

--- a/Facio/PDF/PDFGenerator.swift
+++ b/Facio/PDF/PDFGenerator.swift
@@ -581,7 +581,7 @@ struct PDFGenerator {
         for tx in document.transactionSignatures {
             let rowHeight: CGFloat = tx.explorerURL == nil ? 24 : 38
             cy = ensurePageSpace(context, y: cy, needed: rowHeight)
-            drawText("\(formatDate(tx.date)) — \(document.currency.format(tx.montant, lang: lang)) via \(tx.blockchain.label)",
+            drawText("\(formatDate(tx.date)) — \(document.currency.format(tx.montant, lang: lang)) \(L10n.paymentProofVia(lang)) \(tx.blockchain.label)",
                      x: mL + 5, y: cy, font: PDFLayout.fontBody, color: PDFLayout.textBlack, context: context)
             cy += 13
 
@@ -801,7 +801,7 @@ struct PDFGenerator {
             // Pas de paiement — on n'affiche rien a droite
         } else if effectivePaymentMode == .crypto,
                   let walletAddress = snapshotWalletAddress ?? document.selectedPaymentWalletAddress(from: company.wallets) {
-            let chainLabel = document.paymentSnapshot?.blockchain?.label ?? document.blockchain?.label ?? "Crypto"
+            let chainLabel = document.paymentSnapshot?.blockchain?.label ?? document.blockchain?.label ?? L10n.paymentCrypto(lang)
             drawText(chainLabel, x: rightX, y: ry, font: PDFLayout.fontSmallBold, color: PDFLayout.textBlack, context: context)
             ry += 12
             drawText(L10n.cryptoTransfer(lang), x: rightX, y: ry, font: PDFLayout.fontSmall, color: PDFLayout.textGray, context: context)

--- a/Facio/Services/AuthService.swift
+++ b/Facio/Services/AuthService.swift
@@ -46,6 +46,7 @@ final class AuthService: Sendable {
     var refreshToken: String = ""
     var error: String?
     var isLoading: Bool = false
+    var language: AppLanguage = .fr
 
     /// true apres envoi du code OTP, en attente de verification
     var awaitingOTP: Bool = false
@@ -93,7 +94,7 @@ final class AuthService: Sendable {
     /// Envoie un code OTP a 6 chiffres par email via Supabase
     func sendOTP(email: String) async {
         guard SyncConfig.isConfigured else {
-            error = "Configuration Supabase manquante"
+            error = L10n.authMissingSupabaseConfiguration(language)
             return
         }
         guard let url = buildURL(path: "/auth/v1/otp") else { return }
@@ -130,7 +131,7 @@ final class AuthService: Sendable {
                    let msg = json["msg"] as? String ?? json["error_description"] as? String ?? json["message"] as? String {
                     error = msg
                 } else {
-                    error = "Erreur d'envoi du code (HTTP \(httpResponse.statusCode))"
+                    error = L10n.authSendCodeFailed(language, statusCode: httpResponse.statusCode)
                 }
             }
         } catch {
@@ -144,7 +145,7 @@ final class AuthService: Sendable {
     /// Verifie le code OTP saisi par l'utilisateur
     func verifyOTP(code: String) async {
         guard SyncConfig.isConfigured else {
-            error = "Configuration Supabase manquante"
+            error = L10n.authMissingSupabaseConfiguration(language)
             return
         }
         guard let url = buildURL(path: "/auth/v1/verify") else { return }
@@ -185,7 +186,7 @@ final class AuthService: Sendable {
                    let msg = json["msg"] as? String ?? json["error_description"] as? String ?? json["message"] as? String {
                     error = msg
                 } else {
-                    error = "Code invalide ou expire"
+                    error = L10n.authInvalidOrExpiredCode(language)
                 }
             }
         } catch {
@@ -220,13 +221,13 @@ final class AuthService: Sendable {
         do {
             let (data, response) = try await URLSession.shared.data(for: request)
             guard let httpResponse = response as? HTTPURLResponse else {
-                error = "Reponse Supabase invalide"
+                error = L10n.authInvalidSupabaseResponse(language)
                 return
             }
 
             if httpResponse.statusCode >= 200 && httpResponse.statusCode < 300 {
                 guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                    error = "Reponse Supabase invalide"
+                    error = L10n.authInvalidSupabaseResponse(language)
                     return
                 }
                 handleAuthResponse(json)
@@ -242,7 +243,7 @@ final class AuthService: Sendable {
                let msg = json["msg"] as? String ?? json["error_description"] as? String ?? json["message"] as? String {
                 error = msg
             } else {
-                error = "Erreur de rafraichissement de session (HTTP \(httpResponse.statusCode))"
+                error = L10n.authRefreshSessionFailed(language, statusCode: httpResponse.statusCode)
             }
         } catch {
             self.error = error.localizedDescription
@@ -350,7 +351,7 @@ final class AuthService: Sendable {
                 try KeychainService.set(refreshToken, for: KeychainAccount.refreshToken)
             }
         } catch {
-            self.error = "Erreur de migration de la session"
+            self.error = L10n.authSessionMigrationFailed(language)
         }
     }
 
@@ -380,7 +381,7 @@ final class AuthService: Sendable {
             }
             persistSessionState()
         } catch {
-            self.error = "Erreur de migration de la session"
+            self.error = L10n.authSessionMigrationFailed(language)
         }
     }
 
@@ -397,7 +398,7 @@ final class AuthService: Sendable {
                 try KeychainService.set(refreshToken, for: KeychainAccount.refreshToken)
             }
         } catch {
-            self.error = "Erreur d'enregistrement de la session"
+            self.error = L10n.authSessionSaveFailed(language)
         }
     }
 
@@ -420,34 +421,34 @@ final class AuthService: Sendable {
               let scheme = components.scheme?.lowercased(),
               let host = components.host,
               !host.isEmpty else {
-            if reportErrors { error = "URL Supabase invalide" }
+            if reportErrors { error = L10n.authInvalidSupabaseURL(language) }
             return nil
         }
 
         guard components.user == nil,
               components.password == nil,
               components.fragment == nil else {
-            if reportErrors { error = "URL Supabase invalide" }
+            if reportErrors { error = L10n.authInvalidSupabaseURL(language) }
             return nil
         }
 
         if scheme == "http" {
             #if DEBUG
             guard isLocalhost(host) else {
-                if reportErrors { error = "URL Supabase non securisee" }
+                if reportErrors { error = L10n.authInsecureSupabaseURL(language) }
                 return nil
             }
             #else
-            if reportErrors { error = "URL Supabase non securisee" }
+            if reportErrors { error = L10n.authInsecureSupabaseURL(language) }
             return nil
             #endif
         } else if scheme != "https" {
-            if reportErrors { error = "URL Supabase invalide" }
+            if reportErrors { error = L10n.authInvalidSupabaseURL(language) }
             return nil
         }
 
         guard let pathComponents = URLComponents(string: path) else {
-            if reportErrors { error = "URL Supabase invalide" }
+            if reportErrors { error = L10n.authInvalidSupabaseURL(language) }
             return nil
         }
 

--- a/Facio/Services/DataStore.swift
+++ b/Facio/Services/DataStore.swift
@@ -70,7 +70,10 @@ final class DataStore: Sendable {
                 try fileManager.createDirectory(at: storageDirectory, withIntermediateDirectories: true)
                 persistenceErrors.removeValue(forKey: "storage")
             } catch {
-                persistenceErrors["storage"] = "Impossible de creer le dossier de stockage: \(error.localizedDescription)"
+                persistenceErrors["storage"] = L10n.storageFolderCreationFailed(
+                    companyInfo.langueParDefaut,
+                    error: error.localizedDescription
+                )
             }
         }
     }
@@ -102,8 +105,14 @@ final class DataStore: Sendable {
             writeBlockedKeys.insert(key)
             let backupURL = backupCorruptFile(at: url, key: key.rawValue)
             corruptBackupURLs[key.rawValue] = backupURL
-            let backupPath = backupURL?.lastPathComponent ?? "backup indisponible"
-            persistenceErrors[key.rawValue] = "Lecture impossible de \(url.lastPathComponent): \(error.localizedDescription). Fichier preserve: \(backupPath)"
+            let lang = companyInfo.langueParDefaut
+            let backupPath = backupURL?.lastPathComponent ?? L10n.backupUnavailable(lang)
+            persistenceErrors[key.rawValue] = L10n.persistenceReadFailed(
+                lang,
+                fileName: url.lastPathComponent,
+                error: error.localizedDescription,
+                backupPath: backupPath
+            )
         }
     }
 
@@ -266,7 +275,10 @@ final class DataStore: Sendable {
         ensureStorageDirectory()
 
         guard allowBlockedWrite || !writeBlockedKeys.contains(key) else {
-            persistenceErrors[key.rawValue] = "Sauvegarde bloquee pour \(url.lastPathComponent): le fichier local n'a pas pu etre decode au chargement."
+            persistenceErrors[key.rawValue] = L10n.persistenceSaveBlocked(
+                companyInfo.langueParDefaut,
+                fileName: url.lastPathComponent
+            )
             return false
         }
 
@@ -279,7 +291,11 @@ final class DataStore: Sendable {
             writeBlockedKeys.remove(key)
             return true
         } catch {
-            persistenceErrors[key.rawValue] = "Sauvegarde impossible de \(url.lastPathComponent): \(error.localizedDescription)"
+            persistenceErrors[key.rawValue] = L10n.persistenceSaveFailed(
+                companyInfo.langueParDefaut,
+                fileName: url.lastPathComponent,
+                error: error.localizedDescription
+            )
             return false
         }
     }
@@ -300,7 +316,11 @@ final class DataStore: Sendable {
             try fileManager.copyItem(at: url, to: targetURL)
             return targetURL
         } catch {
-            persistenceErrors["\(key).backup"] = "Backup impossible de \(url.lastPathComponent): \(error.localizedDescription)"
+            persistenceErrors["\(key).backup"] = L10n.persistenceBackupFailed(
+                companyInfo.langueParDefaut,
+                fileName: url.lastPathComponent,
+                error: error.localizedDescription
+            )
             return nil
         }
     }

--- a/Facio/Services/ExportService.swift
+++ b/Facio/Services/ExportService.swift
@@ -43,9 +43,9 @@ struct ExportService {
     static func exportCSV(data: Data, defaultFilename: String, language: AppLanguage = .fr) async -> ExportResult {
         let panel = NSSavePanel()
         panel.allowedContentTypes = [.commaSeparatedText]
-        panel.nameFieldStringValue = sanitizedFilename(defaultFilename, fallback: "time-entries", extension: "csv")
+        panel.nameFieldStringValue = sanitizedFilename(defaultFilename, fallback: L10n.defaultCSVName(language), extension: "csv")
         panel.title = L10n.exportDocument(language)
-        panel.message = L10n.chooseSaveLocation(language)
+        panel.message = L10n.chooseCSVSaveLocation(language)
         panel.canCreateDirectories = true
 
         let response = panel.runModal()

--- a/Facio/Services/SyncService.swift
+++ b/Facio/Services/SyncService.swift
@@ -11,6 +11,7 @@ final class SyncService: Sendable {
     var lastError: String?
     var syncState: SyncState = SyncState()
     var authService: AuthService?
+    var language: AppLanguage = .fr
 
     private let encoder: JSONEncoder = {
         let e = JSONEncoder()
@@ -107,7 +108,7 @@ final class SyncService: Sendable {
                     syncState.setDirty(false, for: .documents)
                 }
             } else {
-                lastError = "Lecture locale impossible: documents.json"
+                lastError = L10n.syncLocalReadFailed(language, fileName: "documents.json")
             }
         }
 
@@ -118,7 +119,7 @@ final class SyncService: Sendable {
                     syncState.setDirty(false, for: .clients)
                 }
             } else {
-                lastError = "Lecture locale impossible: clients.json"
+                lastError = L10n.syncLocalReadFailed(language, fileName: "clients.json")
             }
         }
 
@@ -129,7 +130,7 @@ final class SyncService: Sendable {
                     syncState.setDirty(false, for: .company)
                 }
             } else {
-                lastError = "Lecture locale impossible: company.json"
+                lastError = L10n.syncLocalReadFailed(language, fileName: "company.json")
             }
         }
 
@@ -140,7 +141,7 @@ final class SyncService: Sendable {
                     syncState.setDirty(false, for: .timesheets)
                 }
             } else {
-                lastError = "Lecture locale impossible: timesheets.json"
+                lastError = L10n.syncLocalReadFailed(language, fileName: "timesheets.json")
             }
         }
 
@@ -958,9 +959,9 @@ final class SyncService: Sendable {
             markDirty(key)
         }
         if dirtyAfterPush.hasDirtyData || skippedPulledData || dirtyGeneration != pullGeneration {
-            lastError = "Synchronisation partielle: des donnees locales restent a envoyer."
+            lastError = L10n.syncPartialLocalDataPending(language)
         } else if localSaveFailed {
-            lastError = "Synchronisation partielle: sauvegarde locale impossible."
+            lastError = L10n.syncPartialLocalSaveFailed(language)
         }
 
         syncState.lastFullSyncAt = Date()
@@ -1059,6 +1060,9 @@ final class SyncService: Sendable {
     private func fetchRemoteIdsOrFail(table: String, query: String) async -> Set<String>? {
         do {
             return try await fetchRemoteIds(table: table, query: query)
+        } catch let error as RemoteIdFetchError {
+            lastError = error.description(language: language)
+            return nil
         } catch {
             lastError = error.localizedDescription
             return nil
@@ -1127,7 +1131,7 @@ final class SyncService: Sendable {
                    let msg = json["message"] as? String ?? json["msg"] as? String {
                     lastError = msg
                 } else {
-                    lastError = "Erreur HTTP \(httpResponse.statusCode)"
+                    lastError = L10n.syncHTTPError(language, statusCode: httpResponse.statusCode)
                 }
             }
             return false
@@ -1293,29 +1297,25 @@ final class SyncService: Sendable {
 
     private static let decimalLocale = Locale(identifier: "en_US_POSIX")
 
-    private enum RemoteIdFetchError: LocalizedError {
+    private enum RemoteIdFetchError: Error {
         case invalidURL(table: String)
         case invalidResponse(table: String)
         case httpStatus(table: String, statusCode: Int, message: String?)
         case invalidPayload(table: String)
         case requestFailed(table: String, error: Error)
 
-        var errorDescription: String? {
+        func description(language: AppLanguage) -> String {
             switch self {
             case .invalidURL(let table):
-                return "URL Supabase invalide pour \(table)."
+                return L10n.syncRemoteIDsInvalidURL(language, table: table)
             case .invalidResponse(let table):
-                return "Reponse Supabase invalide pendant la lecture des IDs \(table)."
+                return L10n.syncRemoteIDsInvalidResponse(language, table: table)
             case .httpStatus(let table, let statusCode, let message):
-                if let message, !message.isEmpty {
-                    return "Lecture des IDs \(table) impossible: HTTP \(statusCode) - \(message)"
-                } else {
-                    return "Lecture des IDs \(table) impossible: HTTP \(statusCode)"
-                }
+                return L10n.syncRemoteIDsHTTPStatus(language, table: table, statusCode: statusCode, message: message)
             case .invalidPayload(let table):
-                return "Payload Supabase invalide pendant la lecture des IDs \(table)."
+                return L10n.syncRemoteIDsInvalidPayload(language, table: table)
             case .requestFailed(let table, let error):
-                return "Lecture des IDs \(table) impossible: \(error.localizedDescription)"
+                return L10n.syncRemoteIDsRequestFailed(language, table: table, error: error.localizedDescription)
             }
         }
     }

--- a/Facio/Services/TimeTrackingService.swift
+++ b/Facio/Services/TimeTrackingService.swift
@@ -140,26 +140,13 @@ enum TimeTrackingService {
         timesheet: TimesheetPeriod,
         roundingMode: TimeEntryRoundingMode = .none,
         roundingIntervalMinutes: Int = 1,
-        lang: AppLanguage
+        lang: AppLanguage,
+        numberFormat: AppLanguage? = nil
     ) -> String {
-        let header = [
-            "date",
-            "description",
-            "client",
-            "project",
-            "task",
-            "tags",
-            "start",
-            "end",
-            "duration_raw",
-            "duration_rounded",
-            "billable",
-            "hourly_rate",
-            "amount",
-            "currency",
-            "invoiced",
-            "invoice_number",
-        ].joined(separator: ",")
+        let valueFormat = numberFormat ?? lang
+        let header = L10n.csvHeaders(lang)
+            .map(csvEscape)
+            .joined(separator: ",")
 
         let rows = entries
             .filter { !$0.isDeleted }
@@ -187,8 +174,8 @@ enum TimeTrackingService {
                     String(rawSeconds),
                     String(roundedSeconds),
                     entry.isBillable ? "true" : "false",
-                    rate.formattedDecimal(maxFractionDigits: 2, for: lang),
-                    amount.formattedDecimal(maxFractionDigits: 2, for: lang),
+                    rate.formattedDecimal(maxFractionDigits: 2, for: valueFormat),
+                    amount.formattedDecimal(maxFractionDigits: 2, for: valueFormat),
                     currency,
                     entry.isInvoiced ? "true" : "false",
                     entry.invoiceDocumentId?.uuidString ?? "",

--- a/Facio/Views/Documents/DocumentEditorView.swift
+++ b/Facio/Views/Documents/DocumentEditorView.swift
@@ -547,7 +547,7 @@ struct DocumentEditorView: View {
                                 .font(.subheadline)
                                 .foregroundStyle(.secondary)
                             HStack(spacing: 8) {
-                                Text("1 \(document.currency.label) =")
+                                Text(L10n.exchangeRatePrefix(lang, source: document.currency.label))
                                     .foregroundStyle(.secondary)
                                 DecimalField(
                                     placeholder: L10n.exchangeRateHint(

--- a/Facio/Views/Settings/CompanySettingsView.swift
+++ b/Facio/Views/Settings/CompanySettingsView.swift
@@ -35,7 +35,7 @@ struct CompanySettingsView: View {
 
                     HStack(alignment: .top, spacing: 12) {
                         settingsRow(L10n.postalCode(lang)) {
-                            TextField("54000", text: Binding(
+                            TextField(L10n.postalCodePlaceholder(lang), text: Binding(
                                 get: { company.codePostal },
                                 set: { company.codePostal = $0; dataStore.companyUpdated() }
                             ))
@@ -52,8 +52,8 @@ struct CompanySettingsView: View {
                         }
                     }
 
-                    settingsRow("SIRET") {
-                        TextField("000 000 000 00000", text: Binding(
+                    settingsRow(L10n.siret(lang)) {
+                        TextField(L10n.siretPlaceholder(lang), text: Binding(
                             get: { company.siret },
                             set: { company.siret = $0; dataStore.companyUpdated() }
                         ))
@@ -70,7 +70,7 @@ struct CompanySettingsView: View {
                         .font(.headline)
 
                     settingsRow(L10n.phone(lang)) {
-                        TextField("06 00 00 00 00", text: Binding(
+                        TextField(L10n.phonePlaceholder(lang), text: Binding(
                             get: { company.telephone },
                             set: { company.telephone = $0; dataStore.companyUpdated() }
                         ))
@@ -78,7 +78,7 @@ struct CompanySettingsView: View {
                     }
 
                     settingsRow(L10n.email(lang)) {
-                        TextField("contact@entreprise.fr", text: Binding(
+                        TextField(L10n.contactEmailPlaceholder(lang), text: Binding(
                             get: { company.email },
                             set: { company.email = $0; dataStore.companyUpdated() }
                         ))

--- a/Facio/Views/Settings/LanguageSettingsView.swift
+++ b/Facio/Views/Settings/LanguageSettingsView.swift
@@ -48,8 +48,8 @@ struct LanguageSettingsView: View {
                             get: { company.formatDate },
                             set: { company.formatDate = $0; dataStore.companyUpdated() }
                         )) {
-                            Text("dd/MM/yyyy (02/04/2026)").tag(AppLanguage.fr)
-                            Text("MM/dd/yyyy (04/02/2026)").tag(AppLanguage.en)
+                            Text(L10n.frenchDateFormatSample(lang)).tag(AppLanguage.fr)
+                            Text(L10n.englishDateFormatSample(lang)).tag(AppLanguage.en)
                         }
                         .labelsHidden()
                         .frame(maxWidth: 300)
@@ -69,8 +69,8 @@ struct LanguageSettingsView: View {
                             get: { company.formatNombre },
                             set: { company.formatNombre = $0; dataStore.companyUpdated() }
                         )) {
-                            Text("1 234,56 (FR)").tag(AppLanguage.fr)
-                            Text("1,234.56 (EN)").tag(AppLanguage.en)
+                            Text(L10n.frenchNumberFormatSample(lang)).tag(AppLanguage.fr)
+                            Text(L10n.englishNumberFormatSample(lang)).tag(AppLanguage.en)
                         }
                         .labelsHidden()
                         .frame(maxWidth: 300)

--- a/Facio/Views/Settings/PaymentSettingsView.swift
+++ b/Facio/Views/Settings/PaymentSettingsView.swift
@@ -140,7 +140,7 @@ private struct BankAccountRow: View {
                 }
 
                 settingsRow(L10n.iban(lang)) {
-                    TextField("FR76 0000 0000 0000 0000 0000 000", text: Binding(
+                    TextField(L10n.ibanPlaceholder(lang), text: Binding(
                         get: { account?.iban ?? "" },
                         set: { setAccountValue(\.iban, to: $0) }
                     ))
@@ -150,7 +150,7 @@ private struct BankAccountRow: View {
 
                 HStack(spacing: 12) {
                     settingsRow(L10n.bic(lang)) {
-                        TextField("BNPAFRPP", text: Binding(
+                        TextField(L10n.bicPlaceholder(lang), text: Binding(
                             get: { account?.bic ?? "" },
                             set: { setAccountValue(\.bic, to: $0) }
                         ))

--- a/Facio/Views/Settings/SyncSettingsView.swift
+++ b/Facio/Views/Settings/SyncSettingsView.swift
@@ -70,7 +70,7 @@ struct SyncSettingsView: View {
                             }
 
                             settingsRow(L10n.verificationCode(lang)) {
-                                TextField("123456", text: $otpCode)
+                                TextField(L10n.otpCodePlaceholder(lang), text: $otpCode)
                                     .textFieldStyle(.roundedBorder)
                                     .frame(maxWidth: 200)
                             }
@@ -115,7 +115,7 @@ struct SyncSettingsView: View {
                                 .foregroundStyle(.secondary)
 
                             settingsRow(L10n.email(lang)) {
-                                TextField("email@exemple.com", text: $email)
+                                TextField(L10n.emailPlaceholder(lang), text: $email)
                                     .textFieldStyle(.roundedBorder)
                             }
 
@@ -161,7 +161,7 @@ struct SyncSettingsView: View {
                                 Text(L10n.lastSync(lang))
                                     .foregroundStyle(.secondary)
                                 Spacer()
-                                Text(lastSync.frenchFormatted)
+                                Text(lastSync.formattedDate(for: lang))
                             }
                             .font(.subheadline)
                         }
@@ -209,7 +209,7 @@ struct SyncSettingsView: View {
 
                         if useCustomDB {
                             settingsRow(L10n.supabaseURL(lang)) {
-                                TextField("https://xxx.supabase.co", text: $customURL)
+                                TextField(L10n.supabaseURLPlaceholder(lang), text: $customURL)
                                     .textFieldStyle(.roundedBorder)
                                     .onChange(of: customURL) { SyncConfig.customURL = customURL }
                             }
@@ -217,7 +217,7 @@ struct SyncSettingsView: View {
                             settingsRow(L10n.apiKeyAnon(lang)) {
                                 HStack {
                                     if showApiKey {
-                                        TextField("eyJhbG...", text: $customAPIKey)
+                                        TextField(L10n.apiKeyPlaceholder(lang), text: $customAPIKey)
                                             .textFieldStyle(.roundedBorder)
                                     } else {
                                         SecureField(L10n.apiKey(lang), text: $customAPIKey)
@@ -266,6 +266,13 @@ struct SyncSettingsView: View {
             Spacer()
         }
         .padding(24)
+        .onAppear(perform: updateServiceLanguages)
+        .onChange(of: lang) { _, _ in updateServiceLanguages() }
+    }
+
+    private func updateServiceLanguages() {
+        authService.language = lang
+        syncService.language = lang
     }
 
     private func settingsRow<Content: View>(_ label: String, @ViewBuilder content: () -> Content) -> some View {

--- a/Facio/Views/Sidebar/SidebarView.swift
+++ b/Facio/Views/Sidebar/SidebarView.swift
@@ -14,15 +14,7 @@ enum SidebarSection: String, Hashable, Identifiable {
     var id: String { rawValue }
 
     var label: String {
-        switch self {
-        case .factures: return "Factures"
-        case .devis: return "Devis"
-        case .clients: return "Clients"
-        case .heures: return "Heures & facturation"
-        case .planning: return "Hub temps"
-        case .dashboard: return "Tableau de bord"
-        case .parametres: return "Paramètres"
-        }
+        label(for: .fr)
     }
 
     func label(for lang: AppLanguage) -> String {

--- a/Facio/Views/Timesheet/TimeTrackerPanel.swift
+++ b/Facio/Views/Timesheet/TimeTrackerPanel.swift
@@ -592,13 +592,14 @@ struct TimeTrackerPanel: View {
         let csv = TimeTrackingService.csv(
             for: filteredEntries,
             timesheet: timesheet,
-            lang: numberFormat
+            lang: lang,
+            numberFormat: numberFormat
         )
         guard let data = csv.data(using: .utf8) else { return }
         Task {
             _ = await ExportService.exportCSV(
                 data: data,
-                defaultFilename: "time-entries-\(timesheet.activeStartDateString)-\(timesheet.activeEndDateString)",
+                defaultFilename: "\(L10n.defaultCSVName(lang))-\(timesheet.activeStartDateString)-\(timesheet.activeEndDateString)",
                 language: lang
             )
         }

--- a/Facio/Views/Timesheet/TimesheetEditorView.swift
+++ b/Facio/Views/Timesheet/TimesheetEditorView.swift
@@ -140,7 +140,7 @@ struct TimesheetEditorView: View {
                     Text(L10n.totalHours(lang))
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                    Text("\(heures.formatted2Decimals)h")
+                    Text("\(heures.formatted2Decimals(for: numberFormat))h")
                         .font(.title3.monospacedDigit())
                         .fontWeight(.bold)
                 }
@@ -149,7 +149,7 @@ struct TimesheetEditorView: View {
                     Text(L10n.grossTotal(lang))
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                    Text(brut.formatted2Decimals)
+                    Text(brut.formatted2Decimals(for: numberFormat))
                         .font(.title3.monospacedDigit())
                         .fontWeight(.bold)
                 }
@@ -158,7 +158,7 @@ struct TimesheetEditorView: View {
                     Text(L10n.netTotal(lang))
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                    Text(net.formatted2Decimals)
+                    Text(net.formatted2Decimals(for: numberFormat))
                         .font(.title3.monospacedDigit())
                         .fontWeight(.bold)
                 }
@@ -307,14 +307,14 @@ struct TimesheetEditorView: View {
             LazyVGrid(columns: [
                 GridItem(.adaptive(minimum: 100, maximum: 160))
             ], spacing: 12) {
-                resumeCard(title: L10n.totalHours(lang), value: "\(heuresMois.formatted2Decimals)h", color: .primary)
-                resumeCard(title: L10n.normalHours(lang), value: "\(heuresNorm.formatted2Decimals)h", color: .blue)
-                resumeCard(title: L10n.overtimeHours(lang), value: "\(heuresSup.formatted2Decimals)h",
+                resumeCard(title: L10n.totalHours(lang), value: "\(heuresMois.formatted2Decimals(for: numberFormat))h", color: .primary)
+                resumeCard(title: L10n.normalHours(lang), value: "\(heuresNorm.formatted2Decimals(for: numberFormat))h", color: .blue)
+                resumeCard(title: L10n.overtimeHours(lang), value: "\(heuresSup.formatted2Decimals(for: numberFormat))h",
                            color: heuresSup > 0 ? .orange : .secondary)
-                resumeCard(title: L10n.normalCost(lang), value: coutNorm.formatted2Decimals, color: .secondary)
-                resumeCard(title: L10n.overtimeCost(lang), value: coutSup.formatted2Decimals, color: .secondary)
-                resumeCard(title: L10n.grossTotal(lang), value: brut.formatted2Decimals, color: .green)
-                resumeCard(title: L10n.netTotal(lang), value: net.formatted2Decimals, color: .green)
+                resumeCard(title: L10n.normalCost(lang), value: coutNorm.formatted2Decimals(for: numberFormat), color: .secondary)
+                resumeCard(title: L10n.overtimeCost(lang), value: coutSup.formatted2Decimals(for: numberFormat), color: .secondary)
+                resumeCard(title: L10n.grossTotal(lang), value: brut.formatted2Decimals(for: numberFormat), color: .green)
+                resumeCard(title: L10n.netTotal(lang), value: net.formatted2Decimals(for: numberFormat), color: .green)
             }
             .padding(8)
         }
@@ -376,14 +376,14 @@ struct TimesheetEditorView: View {
                     }
                     Spacer()
                     HStack(spacing: 16) {
-                        Label("\(heuresMoisSemaine.formatted2Decimals)h", systemImage: "clock")
+                        Label("\(heuresMoisSemaine.formatted2Decimals(for: numberFormat))h", systemImage: "clock")
                             .font(.subheadline.monospacedDigit())
                             .fontWeight(.medium)
-                        Text(L10n.normalHoursShort(lang, value: normSemaine.formatted2Decimals))
+                        Text(L10n.normalHoursShort(lang, value: normSemaine.formatted2Decimals(for: numberFormat)))
                             .font(.caption.monospacedDigit())
                             .foregroundStyle(.blue)
                         if supSemaine > 0 {
-                            Text(L10n.overtimeHoursShort(lang, value: supSemaine.formatted2Decimals))
+                            Text(L10n.overtimeHoursShort(lang, value: supSemaine.formatted2Decimals(for: numberFormat)))
                                 .font(.caption.monospacedDigit())
                                 .foregroundStyle(.orange)
                                 .fontWeight(.medium)
@@ -391,7 +391,7 @@ struct TimesheetEditorView: View {
                         Divider().frame(height: 14)
                         let coutSemaine = normSemaine * timesheet.tauxNormal
                             + supSemaine * timesheet.tauxSupplementaire
-                        Text(coutSemaine.formatted2Decimals)
+                        Text(coutSemaine.formatted2Decimals(for: numberFormat))
                             .font(.subheadline.monospacedDigit())
                             .fontWeight(.semibold)
                             .foregroundStyle(.green)


### PR DESCRIPTION
Fixes #67

## Summary
- Added service/export localization coverage with `L10n+Services` for auth, sync, persistence, CSV headers, and save-dialog messages.
- Replaced remaining hardcoded settings, sidebar, PDF, document, and timesheet user-facing strings with `L10n.*(lang)`.
- Plumbed active language into auth/sync service errors and cleaned FR/EN wording plus number/date formatting in affected flows.

## Validation
- `swift build`
- `git diff --check`
- Focused `rg` audit for hardcoded UI/service strings

## Notes
- Technical literals remain intentionally: SF Symbols, URLs, JSON/SQL keys, Codable raw values, brand text, and sentinel IDs.
- Local `gh auth status` reports an invalid token, so this PR was opened through the GitHub connector.