### PR TITLE
fix(sync): distrust remote payment snapshots

### DIFF
--- a/Facio/Diagnostics/RegressionSuite.swift
+++ b/Facio/Diagnostics/RegressionSuite.swift
@@ -60,6 +60,7 @@ enum FacioRegressionSuite {
         RegressionCase(name: "crypto payment selects only compatible non-blank wallets", run: cryptoPaymentSelectsOnlyCompatibleNonBlankWallets),
         RegressionCase(name: "payment snapshot freezes exported bank account", run: paymentSnapshotFreezesExportedBankAccount),
         RegressionCase(name: "payment snapshot survives codable round trip", run: paymentSnapshotSurvivesCodableRoundTrip),
+        RegressionCase(name: "untrusted payment snapshots do not override configured payments", run: untrustedPaymentSnapshotsDoNotOverrideConfiguredPayments),
         RegressionCase(name: "paid invoices do not expose Solana Pay request", run: paidInvoicesDoNotExposeSolanaPayRequest),
         RegressionCase(name: "bitcoin payment is crypto but not Solana Pay eligible", run: bitcoinPaymentIsCryptoButNotSolanaPayEligible),
         RegressionCase(name: "document duplication keeps payment and line data without reusing identity", run: documentDuplicationKeepsPaymentAndLineDataWithoutReusingIdentity),
@@ -473,6 +474,27 @@ enum FacioRegressionSuite {
 
         decoded.currency = .eur
         try expect(decoded.paymentSnapshot == nil, "changing currency should clear stale payment snapshot")
+    }
+
+    private static func untrustedPaymentSnapshotsDoNotOverrideConfiguredPayments() throws {
+        let wallet = WalletEntry(blockchain: .solana, address: "LegitSolAddr", label: "Main")
+        let company = CompanyInfo()
+        company.wallets = [wallet]
+
+        let document = Document(type: .facture, number: "F-REMOTE", currency: .usdc, blockchain: .solana)
+        document.paymentMode = .crypto
+        document.selectedWalletId = wallet.id
+        document.ajouterLigne(LineItem(quantite: decimal("1"), prixUnitaire: decimal("10")))
+        document.normalizePaymentConfiguration(availableWallets: company.wallets)
+        document.paymentSnapshot = DocumentPaymentSnapshot(
+            paymentModeRawValue: PaymentMode.crypto.rawValue,
+            blockchainRawValue: Blockchain.solana.rawValue,
+            walletAddress: "AttackerSolAddr",
+            isTrustedForExport: false
+        )
+
+        try expect(document.trustedPaymentSnapshot == nil, "remote sync snapshots should not be trusted for export")
+        try expectEqual(document.solanaPayWalletAddress(from: company.wallets), "LegitSolAddr")
     }
 
     private static func paidInvoicesDoNotExposeSolanaPayRequest() throws {

--- a/Facio/Models/Document.swift
+++ b/Facio/Models/Document.swift
@@ -10,6 +10,55 @@ struct DocumentPaymentSnapshot: Codable, Hashable {
     var bic: String = ""
     var accountHolder: String = ""
     var createdAt: Date = Date()
+    var isTrustedForExport: Bool = true
+
+    init(
+        paymentModeRawValue: String = PaymentMode.aucun.rawValue,
+        blockchainRawValue: String? = nil,
+        walletAddress: String = "",
+        bankName: String = "",
+        iban: String = "",
+        bic: String = "",
+        accountHolder: String = "",
+        createdAt: Date = Date(),
+        isTrustedForExport: Bool = true
+    ) {
+        self.paymentModeRawValue = paymentModeRawValue
+        self.blockchainRawValue = blockchainRawValue
+        self.walletAddress = walletAddress
+        self.bankName = bankName
+        self.iban = iban
+        self.bic = bic
+        self.accountHolder = accountHolder
+        self.createdAt = createdAt
+        self.isTrustedForExport = isTrustedForExport
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        paymentModeRawValue = try container.decodeIfPresent(String.self, forKey: .paymentModeRawValue)
+            ?? PaymentMode.aucun.rawValue
+        blockchainRawValue = try container.decodeIfPresent(String.self, forKey: .blockchainRawValue)
+        walletAddress = try container.decodeIfPresent(String.self, forKey: .walletAddress) ?? ""
+        bankName = try container.decodeIfPresent(String.self, forKey: .bankName) ?? ""
+        iban = try container.decodeIfPresent(String.self, forKey: .iban) ?? ""
+        bic = try container.decodeIfPresent(String.self, forKey: .bic) ?? ""
+        accountHolder = try container.decodeIfPresent(String.self, forKey: .accountHolder) ?? ""
+        createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt) ?? Date()
+        isTrustedForExport = try container.decodeIfPresent(Bool.self, forKey: .isTrustedForExport) ?? true
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case paymentModeRawValue
+        case blockchainRawValue
+        case walletAddress
+        case bankName
+        case iban
+        case bic
+        case accountHolder
+        case createdAt
+        case isTrustedForExport
+    }
 
     var paymentMode: PaymentMode {
         PaymentMode(rawValue: paymentModeRawValue) ?? .aucun
@@ -279,9 +328,14 @@ final class Document: Identifiable, Codable, Hashable {
         return calendar.startOfDay(for: dateEcheance) < calendar.startOfDay(for: Date())
     }
 
+    var trustedPaymentSnapshot: DocumentPaymentSnapshot? {
+        guard let paymentSnapshot, paymentSnapshot.isTrustedForExport else { return nil }
+        return paymentSnapshot
+    }
+
     func solanaPayWalletAddress(from wallets: [WalletEntry]) -> String? {
         guard shouldRenderPaymentRequest, isSolanaPayEligible, totalTTC > 0 else { return nil }
-        if let paymentSnapshot,
+        if let paymentSnapshot = trustedPaymentSnapshot,
            paymentSnapshot.paymentMode == .crypto,
            paymentSnapshot.blockchain == .solana {
             let snapshotAddress = paymentSnapshot.walletAddress.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Facio/PDF/PDFGenerator.swift
+++ b/Facio/PDF/PDFGenerator.swift
@@ -641,8 +641,12 @@ struct PDFGenerator {
         11
     }
 
+    private var paymentSnapshot: DocumentPaymentSnapshot? {
+        document.trustedPaymentSnapshot
+    }
+
     private var shouldRenderPaymentDetails: Bool {
-        if let paymentSnapshot = document.paymentSnapshot {
+        if let paymentSnapshot {
             return paymentSnapshot.hasUsablePaymentDetails
         }
 
@@ -657,7 +661,7 @@ struct PDFGenerator {
     }
 
     private var effectivePaymentMode: PaymentMode {
-        document.paymentSnapshot?.paymentMode ?? document.paymentMode
+        paymentSnapshot?.paymentMode ?? document.paymentMode
     }
 
     private func trimmedPaymentValue(_ value: String) -> String {
@@ -691,7 +695,7 @@ struct PDFGenerator {
             return height
         case .virement:
             var height: CGFloat = 12
-            if let snapshot = document.paymentSnapshot, snapshot.paymentMode == .virement {
+            if let snapshot = paymentSnapshot, snapshot.paymentMode == .virement {
                 let bankName = trimmedPaymentValue(snapshot.bankName)
                 if !bankName.isEmpty {
                     height += wrappedTextHeight(bankName, font: PDFLayout.fontSmall, maxWidth: footerRightWidth, lineHeight: footerLineHeight)
@@ -731,7 +735,7 @@ struct PDFGenerator {
     }
 
     private var snapshotWalletAddress: String? {
-        guard let snapshot = document.paymentSnapshot, snapshot.paymentMode == .crypto else { return nil }
+        guard let snapshot = paymentSnapshot, snapshot.paymentMode == .crypto else { return nil }
         let address = snapshot.walletAddress.trimmingCharacters(in: .whitespacesAndNewlines)
         return address.isEmpty ? nil : address
     }
@@ -801,7 +805,7 @@ struct PDFGenerator {
             // Pas de paiement — on n'affiche rien a droite
         } else if effectivePaymentMode == .crypto,
                   let walletAddress = snapshotWalletAddress ?? document.selectedPaymentWalletAddress(from: company.wallets) {
-            let chainLabel = document.paymentSnapshot?.blockchain?.label ?? document.blockchain?.label ?? L10n.paymentCrypto(lang)
+            let chainLabel = paymentSnapshot?.blockchain?.label ?? document.blockchain?.label ?? L10n.paymentCrypto(lang)
             drawText(chainLabel, x: rightX, y: ry, font: PDFLayout.fontSmallBold, color: PDFLayout.textBlack, context: context)
             ry += 12
             drawText(L10n.cryptoTransfer(lang), x: rightX, y: ry, font: PDFLayout.fontSmall, color: PDFLayout.textGray, context: context)
@@ -811,7 +815,7 @@ struct PDFGenerator {
             ry = drawWrappedText(walletAddress, x: rightX, y: ry, font: PDFLayout.fontSmall,
                                  color: PDFLayout.textBlack, context: context, maxWidth: footerRightWidth,
                                  lineHeight: footerLineHeight)
-        } else if let snapshot = document.paymentSnapshot, snapshot.paymentMode == .virement {
+        } else if let snapshot = paymentSnapshot, snapshot.paymentMode == .virement {
             drawText(L10n.bankTransfer(lang), x: rightX, y: ry, font: PDFLayout.fontSmallBold, color: PDFLayout.textBlack, context: context)
             ry += 12
             let bankName = trimmedPaymentValue(snapshot.bankName)

--- a/Facio/Services/SyncService.swift
+++ b/Facio/Services/SyncService.swift
@@ -1207,7 +1207,8 @@ final class SyncService: Sendable {
             iban: dictionary["iban"] as? String ?? "",
             bic: dictionary["bic"] as? String ?? "",
             accountHolder: dictionary["accountHolder"] as? String ?? "",
-            createdAt: parseDate(dictionary["createdAt"]) ?? Date()
+            createdAt: parseDate(dictionary["createdAt"]) ?? Date(),
+            isTrustedForExport: false
         )
     }
 

--- a/Facio/Views/Documents/DocumentEditorView.swift
+++ b/Facio/Views/Documents/DocumentEditorView.swift
@@ -753,7 +753,7 @@ struct DocumentEditorView: View {
     }
 
     private func exporterPDF() {
-        if document.paymentSnapshot == nil {
+        if document.trustedPaymentSnapshot == nil {
             if document.freezePaymentSnapshot(from: company) {
                 saveDocument()
             }


### PR DESCRIPTION
### Motivation
- Prevent remotely-synced `payment_snapshot` JSON from silently overriding locally configured payment destinations used for official exports and Solana Pay QR generation.

### Description
- Add a trust marker to `DocumentPaymentSnapshot` (`isTrustedForExport`) with backwards-compatible decoding and an explicit initializer to keep existing local snapshots trusted by default.
- Make the sync pull path in `SyncService` parse remote snapshots with `isTrustedForExport: false` so incoming snapshots are not automatically authoritative for export.
- Introduce `Document.trustedPaymentSnapshot` and route Solana Pay selection and PDF rendering through it so only trusted snapshots affect exported payment details, otherwise fall back to the visible configured company bank account or wallet.
- Change the export flow in `DocumentEditorView` to re-freeze payment details before generating a PDF when no trusted snapshot exists, and add a regression case to `Diagnostics/RegressionSuite` that verifies an untrusted remote snapshot cannot override the configured wallet.

### Testing
- Ran `git diff --check` to validate no whitespace/index errors, which succeeded.
- Attempted `swift build` but the build was blocked because SwiftPM could not fetch the `SolKit` dependency (`CONNECT tunnel failed, response 403`), so the project/regression suite could not be executed in this environment.
- Added a regression test `untrustedPaymentSnapshotsDoNotOverrideConfiguredPayments` to `Facio/Diagnostics/RegressionSuite.swift`, but it was not run due to the blocked `swift build`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a3e919b9483258d5af4d8db371f03)