### PR TITLE
feat(documents): attach expense receipts to invoices and send by email

### DIFF
--- a/Facio/Localization/L10n+Email.swift
+++ b/Facio/Localization/L10n+Email.swift
@@ -40,8 +40,15 @@ extension L10n {
     static func emailResetTemplate(_ l: AppLanguage) -> String { l == .fr ? "Réinitialiser le modèle" : "Reset template" }
     static func emailPlaceholdersHelp(_ l: AppLanguage) -> String {
         l == .fr
-            ? "Variables disponibles : {client} {number} {amount} {due_date} {company}"
-            : "Available variables: {client} {number} {amount} {due_date} {company}"
+            ? "Variables disponibles : {client} {number} {amount} {due_date} {company} {attachments}"
+            : "Available variables: {client} {number} {amount} {due_date} {company} {attachments}"
+    }
+
+    /// Phrase insérée par {attachments} quand le document a des justificatifs.
+    static func emailAttachmentsLine(_ l: AppLanguage) -> String {
+        l == .fr
+            ? "Les justificatifs associés sont également joints à ce message."
+            : "The related supporting documents are also attached to this message."
     }
 
     // Modèles par défaut (utilisés si l'utilisateur n'a rien personnalisé)
@@ -55,7 +62,7 @@ extension L10n {
 
             Veuillez trouver ci-joint la facture {number} d'un montant de {amount}, à régler avant le {due_date}.
 
-            Les justificatifs associés sont également joints à ce message.
+            {attachments}
 
             Cordialement,
             {company}
@@ -65,7 +72,7 @@ extension L10n {
 
             Please find attached invoice {number} for {amount}, due by {due_date}.
 
-            The related supporting documents are also attached to this message.
+            {attachments}
 
             Best regards,
             {company}

--- a/Facio/Localization/L10n+Email.swift
+++ b/Facio/Localization/L10n+Email.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+// MARK: - Justificatifs (pièces jointes) & envoi par email
+
+extension L10n {
+    // Section justificatifs (éditeur de document)
+    static func attachmentsSection(_ l: AppLanguage) -> String { l == .fr ? "Justificatifs" : "Supporting documents" }
+    static func addAttachment(_ l: AppLanguage) -> String { l == .fr ? "Ajouter un justificatif" : "Add a document" }
+    static func noAttachments(_ l: AppLanguage) -> String { l == .fr ? "Aucun justificatif" : "No supporting documents" }
+    static func noAttachmentsHint(_ l: AppLanguage) -> String {
+        l == .fr ? "Glissez un fichier ici, ou cliquez sur Ajouter (PDF, image)." : "Drag a file here, or click Add (PDF, image)."
+    }
+    static func dropAttachmentHere(_ l: AppLanguage) -> String { l == .fr ? "Déposez vos fichiers ici" : "Drop your files here" }
+    static func attachmentLabelPlaceholder(_ l: AppLanguage) -> String { l == .fr ? "Libellé (ex. Train Nancy⇄Paris)" : "Label (e.g. Train Nancy⇄Paris)" }
+    static func openAttachment(_ l: AppLanguage) -> String { l == .fr ? "Ouvrir" : "Open" }
+    static func attachmentImportFailed(_ l: AppLanguage) -> String {
+        l == .fr ? "Impossible d'importer ce fichier." : "Could not import this file."
+    }
+
+    // Envoi par email
+    static func sendByEmail(_ l: AppLanguage) -> String { l == .fr ? "Envoyer par email" : "Send by email" }
+    static func emailUnavailableTitle(_ l: AppLanguage) -> String { l == .fr ? "Envoi indisponible" : "Send unavailable" }
+    static func emailUnavailableMessage(_ l: AppLanguage) -> String {
+        l == .fr
+            ? "Aucune application de messagerie n'est configurée sur ce Mac. Exportez le PDF à la place."
+            : "No email application is configured on this Mac. Export the PDF instead."
+    }
+
+    // Réglages — Envoi / Email
+    static func settingsEmail(_ l: AppLanguage) -> String { l == .fr ? "Envoi / Email" : "Send / Email" }
+    static func settingsEmailHelp(_ l: AppLanguage) -> String {
+        l == .fr
+            ? "Modèle d'email utilisé pour envoyer vos factures et devis."
+            : "Email template used to send your invoices and quotes."
+    }
+    static func emailTemplateSection(_ l: AppLanguage) -> String { l == .fr ? "Modèle d'email" : "Email template" }
+    static func emailTemplateLanguage(_ l: AppLanguage) -> String { l == .fr ? "Langue du modèle" : "Template language" }
+    static func emailSubjectLabel(_ l: AppLanguage) -> String { l == .fr ? "Objet" : "Subject" }
+    static func emailBodyLabel(_ l: AppLanguage) -> String { l == .fr ? "Message" : "Message" }
+    static func emailResetTemplate(_ l: AppLanguage) -> String { l == .fr ? "Réinitialiser le modèle" : "Reset template" }
+    static func emailPlaceholdersHelp(_ l: AppLanguage) -> String {
+        l == .fr
+            ? "Variables disponibles : {client} {number} {amount} {due_date} {company}"
+            : "Available variables: {client} {number} {amount} {due_date} {company}"
+    }
+
+    // Modèles par défaut (utilisés si l'utilisateur n'a rien personnalisé)
+    static func emailDefaultSubject(_ l: AppLanguage) -> String {
+        l == .fr ? "Facture {number} — {company}" : "Invoice {number} — {company}"
+    }
+    static func emailDefaultBody(_ l: AppLanguage) -> String {
+        l == .fr
+            ? """
+            Bonjour {client},
+
+            Veuillez trouver ci-joint la facture {number} d'un montant de {amount}, à régler avant le {due_date}.
+
+            Les justificatifs associés sont également joints à ce message.
+
+            Cordialement,
+            {company}
+            """
+            : """
+            Hello {client},
+
+            Please find attached invoice {number} for {amount}, due by {due_date}.
+
+            The related supporting documents are also attached to this message.
+
+            Best regards,
+            {company}
+            """
+    }
+}

--- a/Facio/Models/ClientInfo.swift
+++ b/Facio/Models/ClientInfo.swift
@@ -78,6 +78,7 @@ final class ClientInfo: Identifiable, Codable, Hashable {
         document.clientSiret = siret
         document.clientTva = tva
         document.clientApe = ape
+        document.clientEmail = email
     }
 
     // MARK: - Codable

--- a/Facio/Models/CompanyInfo.swift
+++ b/Facio/Models/CompanyInfo.swift
@@ -156,6 +156,26 @@ final class CompanyInfo: Identifiable, Codable {
     // Prestations favorites
     var prestations: [DesignationPreset] = []
 
+    // Modèles d'email (par langue ; vide → modèle par défaut localisé)
+    var emailSubjectTemplateFR: String = ""
+    var emailBodyTemplateFR: String = ""
+    var emailSubjectTemplateEN: String = ""
+    var emailBodyTemplateEN: String = ""
+
+    /// Objet du modèle d'email pour une langue (repli sur le défaut si vide).
+    func emailSubjectTemplate(for lang: AppLanguage) -> String {
+        let stored = (lang == .fr ? emailSubjectTemplateFR : emailSubjectTemplateEN)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return stored.isEmpty ? L10n.emailDefaultSubject(lang) : stored
+    }
+
+    /// Corps du modèle d'email pour une langue (repli sur le défaut si vide).
+    func emailBodyTemplate(for lang: AppLanguage) -> String {
+        let stored = (lang == .fr ? emailBodyTemplateFR : emailBodyTemplateEN)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return stored.isEmpty ? L10n.emailDefaultBody(lang) : stored
+    }
+
     // Valeurs par defaut
     var tauxTVAParDefaut: Decimal = 0
     var delaiPaiementJours: Int = 30
@@ -277,6 +297,7 @@ final class CompanyInfo: Identifiable, Codable {
     enum CodingKeys: String, CodingKey {
         case id, nom, adresse, codePostal, ville, siret, telephone, email, logoData
         case nomBanque, iban, bic, titulaireCompte, bankAccounts, wallets, prestations
+        case emailSubjectTemplateFR, emailBodyTemplateFR, emailSubjectTemplateEN, emailBodyTemplateEN
         case tauxTVAParDefaut, delaiPaiementJours, deviseParDefautRawValue, deviseComptableRawValue, blockchainParDefautRawValue
         case updatedAt
         case langueParDefautRawValue, formatDateRawValue, formatNombreRawValue
@@ -302,6 +323,10 @@ final class CompanyInfo: Identifiable, Codable {
         normalizeBankAccountsFromLegacyFields()
         wallets = try container.decodeOrDefault([WalletEntry].self, forKey: .wallets, default: [])
         prestations = try container.decodeOrDefault([DesignationPreset].self, forKey: .prestations, default: [])
+        emailSubjectTemplateFR = try container.decodeOrDefault(String.self, forKey: .emailSubjectTemplateFR, default: "")
+        emailBodyTemplateFR = try container.decodeOrDefault(String.self, forKey: .emailBodyTemplateFR, default: "")
+        emailSubjectTemplateEN = try container.decodeOrDefault(String.self, forKey: .emailSubjectTemplateEN, default: "")
+        emailBodyTemplateEN = try container.decodeOrDefault(String.self, forKey: .emailBodyTemplateEN, default: "")
         tauxTVAParDefaut = try container.decodeOrDefault(Decimal.self, forKey: .tauxTVAParDefaut, default: 0)
         delaiPaiementJours = try container.decodeOrDefault(Int.self, forKey: .delaiPaiementJours, default: 30)
         deviseParDefautRawValue = try container.decodeOrDefault(String.self, forKey: .deviseParDefautRawValue, default: CurrencyType.usdc.rawValue)
@@ -336,6 +361,10 @@ final class CompanyInfo: Identifiable, Codable {
         try container.encode(bankAccounts, forKey: .bankAccounts)
         try container.encode(wallets, forKey: .wallets)
         try container.encode(prestations, forKey: .prestations)
+        try container.encode(emailSubjectTemplateFR, forKey: .emailSubjectTemplateFR)
+        try container.encode(emailBodyTemplateFR, forKey: .emailBodyTemplateFR)
+        try container.encode(emailSubjectTemplateEN, forKey: .emailSubjectTemplateEN)
+        try container.encode(emailBodyTemplateEN, forKey: .emailBodyTemplateEN)
         try container.encode(tauxTVAParDefaut, forKey: .tauxTVAParDefaut)
         try container.encode(delaiPaiementJours, forKey: .delaiPaiementJours)
         try container.encode(deviseParDefautRawValue, forKey: .deviseParDefautRawValue)

--- a/Facio/Models/Document.swift
+++ b/Facio/Models/Document.swift
@@ -104,10 +104,13 @@ final class Document: Identifiable, Codable, Hashable {
     var clientSiret: String = ""
     var clientTva: String = ""
     var clientApe: String = ""
+    var clientEmail: String = ""
 
     // Relations
     var lignes: [LineItem] = []
     var transactionSignatures: [TransactionSignature] = []
+    /// Justificatifs joints (métadonnées ; fichiers stockés localement par DataStore).
+    var attachments: [DocumentAttachment] = []
     var sourceTimesheetId: UUID?
     var timesheetAutoSyncSignature: String?
 
@@ -504,6 +507,7 @@ final class Document: Identifiable, Codable, Hashable {
         copie.clientSiret = clientSiret
         copie.clientTva = clientTva
         copie.clientApe = clientApe
+        copie.clientEmail = clientEmail
         copie.notes = notes
         copie.langueRawValue = langueRawValue
         copie.paymentModeRawValue = paymentModeRawValue
@@ -540,8 +544,8 @@ final class Document: Identifiable, Codable, Hashable {
         case currencyRawValue, blockchainRawValue, paymentModeRawValue
         case accountingCurrencyRawValue, accountingExchangeRate, accountingExchangeRateDate
         case clientNom, clientAdresse, clientCodePostal, clientVille
-        case clientSiret, clientTva, clientApe
-        case lignes, transactionSignatures, sourceTimesheetId, timesheetAutoSyncSignature
+        case clientSiret, clientTva, clientApe, clientEmail
+        case lignes, transactionSignatures, attachments, sourceTimesheetId, timesheetAutoSyncSignature
         case createdAt, updatedAt, notes, selectedWalletId, selectedBankAccountId, langueRawValue
         case paymentSnapshot
     }
@@ -571,8 +575,10 @@ final class Document: Identifiable, Codable, Hashable {
         clientSiret = try container.decodeOrDefault(String.self, forKey: .clientSiret, default: "")
         clientTva = try container.decodeOrDefault(String.self, forKey: .clientTva, default: "")
         clientApe = try container.decodeOrDefault(String.self, forKey: .clientApe, default: "")
+        clientEmail = try container.decodeOrDefault(String.self, forKey: .clientEmail, default: "")
         lignes = try container.decodeOrDefault([LineItem].self, forKey: .lignes, default: [])
         transactionSignatures = try container.decodeOrDefault([TransactionSignature].self, forKey: .transactionSignatures, default: [])
+        attachments = try container.decodeOrDefault([DocumentAttachment].self, forKey: .attachments, default: [])
         sourceTimesheetId = try? container.decode(UUID.self, forKey: .sourceTimesheetId)
         timesheetAutoSyncSignature = try? container.decode(String.self, forKey: .timesheetAutoSyncSignature)
         createdAt = try container.decodeOrDefault(Date.self, forKey: .createdAt, default: dateCreation)
@@ -606,8 +612,10 @@ final class Document: Identifiable, Codable, Hashable {
         try container.encode(clientSiret, forKey: .clientSiret)
         try container.encode(clientTva, forKey: .clientTva)
         try container.encode(clientApe, forKey: .clientApe)
+        try container.encode(clientEmail, forKey: .clientEmail)
         try container.encode(lignes, forKey: .lignes)
         try container.encode(transactionSignatures, forKey: .transactionSignatures)
+        try container.encode(attachments, forKey: .attachments)
         try container.encodeIfPresent(sourceTimesheetId, forKey: .sourceTimesheetId)
         try container.encodeIfPresent(timesheetAutoSyncSignature, forKey: .timesheetAutoSyncSignature)
         try container.encode(createdAt, forKey: .createdAt)

--- a/Facio/Models/DocumentAttachment.swift
+++ b/Facio/Models/DocumentAttachment.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// Justificatif (pièce jointe) rattaché à un document : billet de train, note de
+/// frais, reçu… Le fichier physique est stocké **localement** par `DataStore`
+/// sous `attachments/<documentId>/<id>.<fileExtension>`. Ce modèle ne porte que
+/// les métadonnées, sérialisées dans `documents.json` (le binaire ne transite
+/// pas par la sync).
+struct DocumentAttachment: Identifiable, Codable, Hashable {
+    var id: UUID = UUID()
+    /// Nom du fichier d'origine (affiché à l'utilisateur).
+    var originalFilename: String = ""
+    /// Extension (sans le point), ex. `pdf`, `jpg`.
+    var fileExtension: String = ""
+    /// Libellé éditable (ex. « Train Nancy⇄Paris »). Vide → on affiche le nom du fichier.
+    var label: String = ""
+    /// Taille en octets (pour affichage).
+    var fileSize: Int = 0
+    var addedAt: Date = Date()
+
+    init(
+        id: UUID = UUID(),
+        originalFilename: String = "",
+        fileExtension: String = "",
+        label: String = "",
+        fileSize: Int = 0,
+        addedAt: Date = Date()
+    ) {
+        self.id = id
+        self.originalFilename = originalFilename
+        self.fileExtension = fileExtension
+        self.label = label
+        self.fileSize = fileSize
+        self.addedAt = addedAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeOrDefault(UUID.self, forKey: .id, default: UUID())
+        originalFilename = try container.decodeOrDefault(String.self, forKey: .originalFilename, default: "")
+        fileExtension = try container.decodeOrDefault(String.self, forKey: .fileExtension, default: "")
+        label = try container.decodeOrDefault(String.self, forKey: .label, default: "")
+        fileSize = try container.decodeOrDefault(Int.self, forKey: .fileSize, default: 0)
+        addedAt = try container.decodeOrDefault(Date.self, forKey: .addedAt, default: Date())
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, originalFilename, fileExtension, label, fileSize, addedAt
+    }
+
+    /// Nom du fichier tel que stocké sur disque.
+    var storedFilename: String {
+        fileExtension.isEmpty ? id.uuidString : "\(id.uuidString).\(fileExtension)"
+    }
+
+    /// Libellé d'affichage (label si renseigné, sinon nom de fichier).
+    var displayName: String {
+        let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? originalFilename : trimmed
+    }
+
+    var isImage: Bool {
+        ["png", "jpg", "jpeg", "heic", "heif", "gif", "tiff", "tif", "bmp"].contains(fileExtension.lowercased())
+    }
+
+    var isPDF: Bool { fileExtension.lowercased() == "pdf" }
+
+    var iconName: String {
+        if isPDF { return "doc.richtext" }
+        if isImage { return "photo" }
+        return "paperclip"
+    }
+
+    /// Taille lisible (Ko/Mo).
+    var formattedSize: String {
+        ByteCountFormatter.string(fromByteCount: Int64(fileSize), countStyle: .file)
+    }
+}

--- a/Facio/Services/DataStore.swift
+++ b/Facio/Services/DataStore.swift
@@ -403,6 +403,7 @@ final class DataStore: Sendable {
             marker.timesheet.updatedAt = Date()
         }
         if persist(.documents, allowBlockedWrite: false) {
+            deleteAttachmentsDirectory(for: doc.id)
             syncService?.markDeleted(doc.id, for: .documents)
             if !affectedTimesheets.isEmpty || !affectedTimeEntries.isEmpty {
                 saveTimesheets()
@@ -429,6 +430,108 @@ final class DataStore: Sendable {
     }
 
     func documentUpdated() {
+        saveDocuments()
+    }
+
+    // MARK: - Document attachments (justificatifs, stockés localement)
+    //
+    // Les fichiers binaires sont copiés dans
+    // `<storage>/attachments/<documentId>/<attachmentId>.<ext>` (perms 0o600).
+    // Seules les métadonnées (`DocumentAttachment`) sont sérialisées dans
+    // documents.json ; les fichiers ne transitent pas par la sync (v1 locale).
+
+    private var attachmentsRootDirectory: URL {
+        storageDirectory.appendingPathComponent("attachments", isDirectory: true)
+    }
+
+    func attachmentsDirectory(for documentId: UUID) -> URL {
+        attachmentsRootDirectory.appendingPathComponent(documentId.uuidString, isDirectory: true)
+    }
+
+    /// URL sur disque d'un justificatif d'un document.
+    func attachmentURL(_ attachment: DocumentAttachment, in document: Document) -> URL {
+        attachmentsDirectory(for: document.id).appendingPathComponent(attachment.storedFilename)
+    }
+
+    /// URLs existantes des justificatifs d'un document (fichiers présents uniquement).
+    func attachmentURLs(for document: Document) -> [URL] {
+        document.attachments
+            .map { attachmentURL($0, in: document) }
+            .filter { fileManager.fileExists(atPath: $0.path) }
+    }
+
+    /// Importe un fichier comme justificatif : copie sur disque, ajoute la
+    /// métadonnée au document et sauvegarde. Retourne nil en cas d'échec.
+    @discardableResult
+    func importAttachment(from sourceURL: URL, to document: Document, label: String = "") -> DocumentAttachment? {
+        let size = (try? sourceURL.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+        let attachment = DocumentAttachment(
+            originalFilename: sourceURL.lastPathComponent,
+            fileExtension: sourceURL.pathExtension,
+            label: label,
+            fileSize: size
+        )
+        let dir = attachmentsDirectory(for: document.id)
+        do {
+            try SecurePersistence.ensureStorageDirectory(at: dir)
+            let dest = dir.appendingPathComponent(attachment.storedFilename)
+            if fileManager.fileExists(atPath: dest.path) {
+                try fileManager.removeItem(at: dest)
+            }
+            try fileManager.copyItem(at: sourceURL, to: dest)
+            try? SecurePersistence.hardenFile(at: dest)
+        } catch {
+            return nil
+        }
+        document.attachments.append(attachment)
+        document.updatedAt = Date()
+        saveDocuments()
+        return attachment
+    }
+
+    /// Met à jour le libellé d'un justificatif.
+    func updateAttachmentLabel(_ attachment: DocumentAttachment, label: String, in document: Document) {
+        guard let index = document.attachments.firstIndex(where: { $0.id == attachment.id }) else { return }
+        document.attachments[index].label = label
+        document.updatedAt = Date()
+        saveDocuments()
+    }
+
+    /// Supprime un justificatif (fichier + métadonnée) et sauvegarde.
+    func deleteAttachment(_ attachment: DocumentAttachment, from document: Document) {
+        try? fileManager.removeItem(at: attachmentURL(attachment, in: document))
+        document.attachments.removeAll { $0.id == attachment.id }
+        document.updatedAt = Date()
+        saveDocuments()
+    }
+
+    /// Supprime tout le dossier de justificatifs d'un document.
+    func deleteAttachmentsDirectory(for documentId: UUID) {
+        try? fileManager.removeItem(at: attachmentsDirectory(for: documentId))
+    }
+
+    /// Copie les justificatifs d'un document vers un autre (nouveaux ids/fichiers).
+    /// Utilisé lors de la duplication d'un document.
+    func duplicateAttachments(from source: Document, to destination: Document) {
+        guard !source.attachments.isEmpty else { return }
+        let destDir = attachmentsDirectory(for: destination.id)
+        try? SecurePersistence.ensureStorageDirectory(at: destDir)
+        var copied: [DocumentAttachment] = []
+        for attachment in source.attachments {
+            let sourceFile = attachmentURL(attachment, in: source)
+            guard fileManager.fileExists(atPath: sourceFile.path) else { continue }
+            var copy = attachment
+            copy.id = UUID()
+            let destFile = destDir.appendingPathComponent(copy.storedFilename)
+            do {
+                try fileManager.copyItem(at: sourceFile, to: destFile)
+                try? SecurePersistence.hardenFile(at: destFile)
+                copied.append(copy)
+            } catch {
+                continue
+            }
+        }
+        destination.attachments = copied
         saveDocuments()
     }
 

--- a/Facio/Services/EmailService.swift
+++ b/Facio/Services/EmailService.swift
@@ -1,0 +1,77 @@
+import AppKit
+import Foundation
+
+/// Envoi d'un document par email via le composer natif macOS (`NSSharingService`).
+/// L'app n'étant pas sandboxée, on attache directement les fichiers du disque.
+enum EmailService {
+    enum SendResult {
+        case composed
+        case unavailable
+    }
+
+    /// Substitue les variables d'un modèle d'email avec les données du document.
+    static func resolveTemplate(_ template: String, document: Document, company: CompanyInfo) -> String {
+        let amount = document.currency.formatAccounting(document.totalTTC, lang: company.formatNombre)
+        let dueDate = document.dateEcheance.formattedDate(for: company.formatDate)
+        return template
+            .replacingOccurrences(of: "{client}", with: document.clientNom)
+            .replacingOccurrences(of: "{number}", with: document.number)
+            .replacingOccurrences(of: "{amount}", with: amount)
+            .replacingOccurrences(of: "{due_date}", with: dueDate)
+            .replacingOccurrences(of: "{company}", with: company.nom)
+    }
+
+    /// Ouvre le composer mail pré-rempli (objet, message, destinataire) avec le
+    /// PDF de la facture et les justificatifs en pièces jointes (fichiers séparés).
+    @MainActor
+    @discardableResult
+    static func composeInvoiceEmail(
+        document: Document,
+        company: CompanyInfo,
+        pdfData: Data,
+        attachmentURLs: [URL]
+    ) -> SendResult {
+        let lang = document.langue
+        let subject = resolveTemplate(company.emailSubjectTemplate(for: lang), document: document, company: company)
+        let body = resolveTemplate(company.emailBodyTemplate(for: lang), document: document, company: company)
+
+        // PDF de la facture → fichier temporaire pour la pièce jointe.
+        let pdfURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(safeFilename(document.number)).pdf")
+        do {
+            try pdfData.write(to: pdfURL, options: .atomic)
+        } catch {
+            return .unavailable
+        }
+
+        var items: [Any] = [body, pdfURL]
+        items.append(contentsOf: attachmentURLs)
+
+        guard let service = NSSharingService(named: .composeEmail),
+              service.canPerform(withItems: items) else {
+            return .unavailable
+        }
+        service.subject = subject
+        let recipient = document.clientEmail.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !recipient.isEmpty {
+            service.recipients = [recipient]
+        }
+        service.perform(withItems: items)
+        return .composed
+    }
+
+    private static func safeFilename(_ base: String) -> String {
+        let cleaned = base.unicodeScalars.map { scalar -> Character in
+            if CharacterSet.alphanumerics.contains(scalar)
+                || CharacterSet(charactersIn: " ._-").contains(scalar) {
+                return Character(scalar)
+            }
+            return "-"
+        }
+        let collapsed = String(cleaned)
+            .split(whereSeparator: { $0 == "-" })
+            .joined(separator: "-")
+            .trimmingCharacters(in: CharacterSet(charactersIn: " ._-"))
+        return collapsed.isEmpty ? "document" : String(collapsed.prefix(120))
+    }
+}

--- a/Facio/Services/EmailService.swift
+++ b/Facio/Services/EmailService.swift
@@ -13,12 +13,24 @@ enum EmailService {
     static func resolveTemplate(_ template: String, document: Document, company: CompanyInfo) -> String {
         let amount = document.currency.formatAccounting(document.totalTTC, lang: company.formatNombre)
         let dueDate = document.dateEcheance.formattedDate(for: company.formatDate)
-        return template
+        let attachmentsLine = document.attachments.isEmpty ? "" : L10n.emailAttachmentsLine(document.langue)
+        let resolved = template
             .replacingOccurrences(of: "{client}", with: document.clientNom)
             .replacingOccurrences(of: "{number}", with: document.number)
             .replacingOccurrences(of: "{amount}", with: amount)
             .replacingOccurrences(of: "{due_date}", with: dueDate)
             .replacingOccurrences(of: "{company}", with: company.nom)
+            .replacingOccurrences(of: "{attachments}", with: attachmentsLine)
+        return collapseBlankLines(resolved)
+    }
+
+    /// Supprime les lignes vides résiduelles laissées par un placeholder vide.
+    private static func collapseBlankLines(_ text: String) -> String {
+        var result = text
+        while result.contains("\n\n\n") {
+            result = result.replacingOccurrences(of: "\n\n\n", with: "\n\n")
+        }
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     /// Ouvre le composer mail pré-rempli (objet, message, destinataire) avec le
@@ -35,10 +47,13 @@ enum EmailService {
         let subject = resolveTemplate(company.emailSubjectTemplate(for: lang), document: document, company: company)
         let body = resolveTemplate(company.emailBodyTemplate(for: lang), document: document, company: company)
 
-        // PDF de la facture → fichier temporaire pour la pièce jointe.
-        let pdfURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("\(safeFilename(document.number)).pdf")
+        // PDF de la facture → fichier temporaire (sous-dossier unique pour
+        // éviter toute collision entre envois).
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("FacioEmail-\(UUID().uuidString)", isDirectory: true)
+        let pdfURL = tempDir.appendingPathComponent("\(safeFilename(document.number)).pdf")
         do {
+            try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
             try pdfData.write(to: pdfURL, options: .atomic)
         } catch {
             return .unavailable
@@ -49,6 +64,7 @@ enum EmailService {
 
         guard let service = NSSharingService(named: .composeEmail),
               service.canPerform(withItems: items) else {
+            try? FileManager.default.removeItem(at: tempDir)
             return .unavailable
         }
         service.subject = subject
@@ -57,6 +73,12 @@ enum EmailService {
             service.recipients = [recipient]
         }
         service.perform(withItems: items)
+
+        // Nettoyage différé : le composer lit le fichier de façon asynchrone,
+        // on ne peut donc pas le supprimer immédiatement après perform().
+        DispatchQueue.main.asyncAfter(deadline: .now() + 300) {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
         return .composed
     }
 

--- a/Facio/Views/Documents/DocumentAttachmentsSection.swift
+++ b/Facio/Views/Documents/DocumentAttachmentsSection.swift
@@ -1,0 +1,169 @@
+import SwiftUI
+import AppKit
+import UniformTypeIdentifiers
+
+/// Section « Justificatifs » de l'éditeur : import de pièces jointes (PDF /
+/// images) par bouton ou glisser-déposer, libellé éditable, ouverture et
+/// suppression. Les fichiers sont stockés localement par `DataStore`.
+struct DocumentAttachmentsSection: View {
+    let document: Document
+    let lang: AppLanguage
+    @Environment(DataStore.self) private var dataStore
+
+    @State private var isDropTargeted = false
+    @State private var importError: String?
+
+    var body: some View {
+        SectionPanel(L10n.attachmentsSection(lang), systemImage: "paperclip") {
+            VStack(alignment: .leading, spacing: FacioLayout.space12) {
+                if document.attachments.isEmpty {
+                    Text(L10n.noAttachmentsHint(lang))
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                        .fixedSize(horizontal: false, vertical: true)
+                } else {
+                    VStack(alignment: .leading, spacing: FacioLayout.space4) {
+                        ForEach(document.attachments) { attachment in
+                            AttachmentRowView(
+                                document: document,
+                                attachment: attachment,
+                                lang: lang,
+                                onOpen: { open(attachment) },
+                                onDelete: { dataStore.deleteAttachment(attachment, from: document) }
+                            )
+                            if attachment.id != document.attachments.last?.id {
+                                Divider()
+                            }
+                        }
+                    }
+                }
+
+                dropZone
+
+                if let importError {
+                    InlineWarning(text: importError, tone: .danger)
+                }
+
+                Button {
+                    pickFiles()
+                } label: {
+                    Label(L10n.addAttachment(lang), systemImage: "plus.circle")
+                }
+                .buttonStyle(.borderless)
+            }
+        }
+    }
+
+    private var dropZone: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: FacioLayout.radiusPanel)
+                .strokeBorder(style: StrokeStyle(lineWidth: 2, dash: [6]))
+                .foregroundStyle(isDropTargeted ? Color.intentInfo : .secondary.opacity(0.4))
+                .frame(height: 60)
+
+            VStack(spacing: FacioLayout.space4) {
+                Image(systemName: "paperclip.badge.ellipsis")
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+                Text(L10n.dropAttachmentHere(lang))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .onDrop(of: [.fileURL], isTargeted: $isDropTargeted) { providers in
+            handleDrop(providers)
+        }
+    }
+
+    private func open(_ attachment: DocumentAttachment) {
+        NSWorkspace.shared.open(dataStore.attachmentURL(attachment, in: document))
+    }
+
+    private func pickFiles() {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.pdf, .png, .jpeg, .heic, .tiff]
+        panel.allowsMultipleSelection = true
+        panel.canChooseDirectories = false
+        guard panel.runModal() == .OK else { return }
+        importError = nil
+        for url in panel.urls where dataStore.importAttachment(from: url, to: document) == nil {
+            importError = L10n.attachmentImportFailed(lang)
+        }
+    }
+
+    private func handleDrop(_ providers: [NSItemProvider]) -> Bool {
+        var handledAny = false
+        for provider in providers where provider.hasItemConformingToTypeIdentifier("public.file-url") {
+            handledAny = true
+            provider.loadItem(forTypeIdentifier: "public.file-url", options: nil) { item, _ in
+                guard let data = item as? Data,
+                      let url = URL(dataRepresentation: data, relativeTo: nil) else { return }
+                DispatchQueue.main.async {
+                    if dataStore.importAttachment(from: url, to: document) == nil {
+                        importError = L10n.attachmentImportFailed(lang)
+                    } else {
+                        importError = nil
+                    }
+                }
+            }
+        }
+        return handledAny
+    }
+}
+
+private struct AttachmentRowView: View {
+    let document: Document
+    let attachment: DocumentAttachment
+    let lang: AppLanguage
+    let onOpen: () -> Void
+    let onDelete: () -> Void
+
+    @Environment(DataStore.self) private var dataStore
+    @State private var labelText: String = ""
+    @FocusState private var labelFocused: Bool
+
+    var body: some View {
+        HStack(spacing: FacioLayout.space10) {
+            Image(systemName: attachment.iconName)
+                .foregroundStyle(Color.appPrimary(from: dataStore.companyInfo))
+                .frame(width: 24)
+
+            VStack(alignment: .leading, spacing: FacioLayout.space2) {
+                TextField(L10n.attachmentLabelPlaceholder(lang), text: $labelText)
+                    .textFieldStyle(.plain)
+                    .font(FacioFont.rowTitle)
+                    .focused($labelFocused)
+                    .onSubmit { commitLabel() }
+                    .onChange(of: labelFocused) { _, focused in
+                        if !focused { commitLabel() }
+                    }
+
+                HStack(spacing: FacioLayout.space6) {
+                    Text(attachment.originalFilename)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Text("•")
+                    Text(attachment.formattedSize)
+                }
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            FacioIconButton(systemImage: "arrow.up.right.square", help: L10n.openAttachment(lang)) {
+                onOpen()
+            }
+            FacioIconButton(systemImage: "trash", tone: .intentDanger, help: L10n.delete(lang)) {
+                onDelete()
+            }
+        }
+        .padding(.vertical, FacioLayout.space4)
+        .onAppear { labelText = attachment.label }
+    }
+
+    private func commitLabel() {
+        guard labelText != attachment.label else { return }
+        dataStore.updateAttachmentLabel(attachment, label: labelText, in: document)
+    }
+}

--- a/Facio/Views/Documents/DocumentAttachmentsSection.swift
+++ b/Facio/Views/Documents/DocumentAttachmentsSection.swift
@@ -79,9 +79,14 @@ struct DocumentAttachmentsSection: View {
         NSWorkspace.shared.open(dataStore.attachmentURL(attachment, in: document))
     }
 
+    /// Types acceptés (cohérents entre sélecteur de fichiers et glisser-déposer).
+    private static let allowedExtensions: Set<String> = [
+        "pdf", "png", "jpg", "jpeg", "heic", "heif", "gif", "tiff", "tif", "bmp"
+    ]
+
     private func pickFiles() {
         let panel = NSOpenPanel()
-        panel.allowedContentTypes = [.pdf, .png, .jpeg, .heic, .tiff]
+        panel.allowedContentTypes = [.pdf, .png, .jpeg, .heic, .gif, .tiff, .bmp]
         panel.allowsMultipleSelection = true
         panel.canChooseDirectories = false
         guard panel.runModal() == .OK else { return }
@@ -92,6 +97,7 @@ struct DocumentAttachmentsSection: View {
     }
 
     private func handleDrop(_ providers: [NSItemProvider]) -> Bool {
+        importError = nil
         var handledAny = false
         for provider in providers where provider.hasItemConformingToTypeIdentifier("public.file-url") {
             handledAny = true
@@ -99,10 +105,12 @@ struct DocumentAttachmentsSection: View {
                 guard let data = item as? Data,
                       let url = URL(dataRepresentation: data, relativeTo: nil) else { return }
                 DispatchQueue.main.async {
+                    guard Self.allowedExtensions.contains(url.pathExtension.lowercased()) else {
+                        importError = L10n.attachmentImportFailed(lang)
+                        return
+                    }
                     if dataStore.importAttachment(from: url, to: document) == nil {
                         importError = L10n.attachmentImportFailed(lang)
-                    } else {
-                        importError = nil
                     }
                 }
             }
@@ -160,6 +168,9 @@ private struct AttachmentRowView: View {
         }
         .padding(.vertical, FacioLayout.space4)
         .onAppear { labelText = attachment.label }
+        .onChange(of: attachment.label) { _, newValue in
+            if !labelFocused { labelText = newValue }
+        }
     }
 
     private func commitLabel() {

--- a/Facio/Views/Documents/DocumentEditorView.swift
+++ b/Facio/Views/Documents/DocumentEditorView.swift
@@ -10,6 +10,7 @@ struct DocumentEditorView: View {
     @State private var showAddSignature = false
     @State private var showPDFGenerationAlert = false
     @State private var showPDFExportAlert = false
+    @State private var showEmailUnavailableAlert = false
     @State private var signatureCountBeforeSheet = 0
 
     // Debounce timer for auto-save
@@ -106,6 +107,11 @@ struct DocumentEditorView: View {
         } message: {
             Text(L10n.cannotExportPDF(lang))
         }
+        .alert(L10n.emailUnavailableTitle(lang), isPresented: $showEmailUnavailableAlert) {
+            Button(L10n.understood(lang), role: .cancel) {}
+        } message: {
+            Text(L10n.emailUnavailableMessage(lang))
+        }
     }
 
     private func documentMainScroll(showInlineInspector: Bool) -> some View {
@@ -126,6 +132,8 @@ struct DocumentEditorView: View {
                 DocumentPaymentInfoView(document: document, company: company, lang: lang) {
                     saveDocument()
                 }
+
+                DocumentAttachmentsSection(document: document, lang: lang)
 
                 if document.status == .payee {
                     DocumentSignaturesSection(
@@ -373,6 +381,12 @@ struct DocumentEditorView: View {
                 exporterPDF()
             } label: {
                 Label(L10n.exportPDF(lang), systemImage: "square.and.arrow.up")
+            }
+
+            Button {
+                envoyerParEmail()
+            } label: {
+                Label(L10n.sendByEmail(lang), systemImage: "paperplane")
             }
         }
     }
@@ -770,6 +784,31 @@ struct DocumentEditorView: View {
             if result == .failed {
                 showPDFExportAlert = true
             }
+        }
+    }
+
+    private func envoyerParEmail() {
+        if document.trustedPaymentSnapshot == nil {
+            if document.freezePaymentSnapshot(from: company) {
+                saveDocument()
+            }
+        }
+
+        let pdfData = PDFGenerator(document: document, company: company).generate()
+        guard !pdfData.isEmpty else {
+            showPDFGenerationAlert = true
+            return
+        }
+
+        let attachmentURLs = dataStore.attachmentURLs(for: document)
+        let result = EmailService.composeInvoiceEmail(
+            document: document,
+            company: company,
+            pdfData: pdfData,
+            attachmentURLs: attachmentURLs
+        )
+        if result == .unavailable {
+            showEmailUnavailableAlert = true
         }
     }
 }

--- a/Facio/Views/Documents/DocumentEditorView.swift
+++ b/Facio/Views/Documents/DocumentEditorView.swift
@@ -754,6 +754,7 @@ struct DocumentEditorView: View {
             language: lang
         )
         dataStore.addDocument(copie)
+        dataStore.duplicateAttachments(from: document, to: copie)
     }
 
     private func convertirEnFacture() {
@@ -764,6 +765,7 @@ struct DocumentEditorView: View {
             language: lang
         )
         dataStore.addDocument(facture)
+        dataStore.duplicateAttachments(from: document, to: facture)
     }
 
     private func exporterPDF() {

--- a/Facio/Views/Documents/DocumentListView.swift
+++ b/Facio/Views/Documents/DocumentListView.swift
@@ -132,6 +132,7 @@ struct DocumentListView: View {
             language: lang
         )
         dataStore.addDocument(copie)
+        dataStore.duplicateAttachments(from: document, to: copie)
         selectedDocumentId = copie.id
     }
 
@@ -143,6 +144,7 @@ struct DocumentListView: View {
             language: lang
         )
         dataStore.addDocument(facture)
+        dataStore.duplicateAttachments(from: document, to: facture)
         onOpenDocument(facture)
     }
 

--- a/Facio/Views/Settings/EmailSettingsView.swift
+++ b/Facio/Views/Settings/EmailSettingsView.swift
@@ -55,6 +55,7 @@ struct EmailSettingsView: View {
             Spacer()
         }
         .padding(FacioLayout.screenPadding)
+        .onAppear { templateLang = dataStore.companyInfo.langueParDefaut }
     }
 
     // Le champ affiche le modèle par défaut tant qu'il n'est pas personnalisé.

--- a/Facio/Views/Settings/EmailSettingsView.swift
+++ b/Facio/Views/Settings/EmailSettingsView.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+
+/// Réglages d'envoi : modèle d'email (objet + message) personnalisable par
+/// langue, avec variables substituées à l'envoi.
+struct EmailSettingsView: View {
+    @Environment(DataStore.self) private var dataStore
+    @State private var templateLang: AppLanguage = .fr
+
+    private var company: CompanyInfo { dataStore.companyInfo }
+    private var lang: AppLanguage { dataStore.companyInfo.langueParDefaut }
+
+    var body: some View {
+        VStack(spacing: FacioLayout.space20) {
+            SectionPanel(L10n.emailTemplateSection(lang), systemImage: "paperplane") {
+                VStack(alignment: .leading, spacing: FacioLayout.space16) {
+                    LabeledField(L10n.emailTemplateLanguage(lang)) {
+                        Picker("", selection: $templateLang) {
+                            ForEach(AppLanguage.allCases) { language in
+                                Text(language.label).tag(language)
+                            }
+                        }
+                        .labelsHidden()
+                        .pickerStyle(.segmented)
+                        .frame(maxWidth: 240)
+                    }
+
+                    LabeledField(L10n.emailSubjectLabel(lang)) {
+                        TextField("", text: subjectBinding)
+                            .textFieldStyle(.roundedBorder)
+                    }
+
+                    LabeledField(L10n.emailBodyLabel(lang)) {
+                        TextEditor(text: bodyBinding)
+                            .font(.body)
+                            .frame(minHeight: 160)
+                            .padding(FacioLayout.space4)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: FacioLayout.radiusField)
+                                    .strokeBorder(Color.borderSubtle, lineWidth: 1)
+                            )
+                    }
+
+                    Text(L10n.emailPlaceholdersHelp(lang))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    Button(L10n.emailResetTemplate(lang)) {
+                        resetTemplate()
+                    }
+                    .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer()
+        }
+        .padding(FacioLayout.screenPadding)
+    }
+
+    // Le champ affiche le modèle par défaut tant qu'il n'est pas personnalisé.
+
+    private var subjectBinding: Binding<String> {
+        Binding(
+            get: { company.emailSubjectTemplate(for: templateLang) },
+            set: { newValue in
+                if templateLang == .fr {
+                    company.emailSubjectTemplateFR = newValue
+                } else {
+                    company.emailSubjectTemplateEN = newValue
+                }
+                dataStore.companyUpdated()
+            }
+        )
+    }
+
+    private var bodyBinding: Binding<String> {
+        Binding(
+            get: { company.emailBodyTemplate(for: templateLang) },
+            set: { newValue in
+                if templateLang == .fr {
+                    company.emailBodyTemplateFR = newValue
+                } else {
+                    company.emailBodyTemplateEN = newValue
+                }
+                dataStore.companyUpdated()
+            }
+        )
+    }
+
+    private func resetTemplate() {
+        if templateLang == .fr {
+            company.emailSubjectTemplateFR = ""
+            company.emailBodyTemplateFR = ""
+        } else {
+            company.emailSubjectTemplateEN = ""
+            company.emailBodyTemplateEN = ""
+        }
+        dataStore.companyUpdated()
+    }
+}

--- a/Facio/Views/Settings/SettingsInlineView.swift
+++ b/Facio/Views/Settings/SettingsInlineView.swift
@@ -14,6 +14,7 @@ struct SettingsInlineView: View {
             (L10n.settingsCompany(lang), "building.2", L10n.settingsCompanyHelp(lang)),
             (L10n.settingsCustomisation(lang), "paintpalette", L10n.settingsCustomisationHelp(lang)),
             (L10n.settingsPayment(lang), "creditcard", L10n.settingsPaymentHelp(lang)),
+            (L10n.settingsEmail(lang), "paperplane", L10n.settingsEmailHelp(lang)),
             (L10n.settingsDefaults(lang), "slider.horizontal.3", L10n.settingsDefaultsHelp(lang)),
             (L10n.settingsServices(lang), "star", L10n.settingsServicesHelp(lang)),
             (L10n.settingsLanguage(lang), "globe", L10n.settingsLanguageHelp(lang)),
@@ -84,11 +85,12 @@ struct SettingsInlineView: View {
         case 0: CompanySettingsView()
         case 1: CustomisationSettingsView()
         case 2: PaymentSettingsView()
-        case 3: DefaultsSettingsView()
-        case 4: PrestationsSettingsView()
-        case 5: LanguageSettingsView()
-        case 6: SyncSettingsView(syncService: syncService, authService: authService)
-        case 7: AboutSettingsView()
+        case 3: EmailSettingsView()
+        case 4: DefaultsSettingsView()
+        case 5: PrestationsSettingsView()
+        case 6: LanguageSettingsView()
+        case 7: SyncSettingsView(syncService: syncService, authService: authService)
+        case 8: AboutSettingsView()
         default: EmptyView()
         }
     }


### PR DESCRIPTION
## Summary

Lets freelancers attach **supporting documents** (train tickets, expense receipts — PDF/images) to an invoice and **send it by email** with the invoice PDF and every attachment already attached (as separate files). Built on the design system from #75. No behaviour regressions; `swift build` is clean and the app launches.

## Changes

**Data model**
- New `DocumentAttachment` (Codable) ; `Document.attachments` + frozen `clientEmail` (set via `ClientInfo.appliquer`), using the existing `decodeOrDefault` backwards-compatible pattern.

**Local storage (DataStore)**
- Files stored locally at `attachments/<documentId>/<id>.<ext>` (hardened 0o600) ; import / delete / cleanup on document deletion ; copy on duplication and quote→invoice conversion. Binaries are **not synced** (v1 local-only); only metadata lives in `documents.json`.

**Editor**
- New **“Justificatifs”** section (`SectionPanel`): import via button (`NSOpenPanel`) and drag-and-drop, editable label, open on click, delete (`FacioIconButton`).

**Email**
- `EmailService` using the native `NSSharingService(.composeEmail)` composer — subject/body from a template, recipient = client email, invoice PDF + attachments as separate attachments ; toolbar **“Send by email”** action with a graceful fallback alert when no mail app is configured.

**Settings**
- New **Send / Email** tab (`EmailSettingsView`): per-language (FR/EN) customizable subject + body templates on `CompanyInfo`, with variables `{client} {number} {amount} {due_date} {company}` and localized defaults.

**i18n**
- All new strings in FR + EN (`L10n+Email.swift`), no hardcoded user-facing strings.

## Testing

- `swift build` — clean, no warnings or errors.
- Launched the app via `swift run` — starts without crash; new section and settings tab present.
- Manual GUI verification (drag-drop import, open/delete, mail composer with attachments, FR/EN templates) recommended before merge — see issue checklist.

## Notes / out of scope (v1)

Attachment sync (Supabase Storage), merging attachments as annex pages into the invoice PDF, auto-send without review, per-client templates.

Closes #77
