### PR TITLE
fix(documents): corriger les fragilités email & justificatifs

### DIFF
--- a/Facio/Diagnostics/RegressionSuite.swift
+++ b/Facio/Diagnostics/RegressionSuite.swift
@@ -109,7 +109,12 @@ enum FacioRegressionSuite {
         RegressionCase(name: "time entry csv report includes billable columns", run: timeEntryCSVReportIncludesBillableColumns),
         RegressionCase(name: "time hub stats exclude deleted entries", run: timeHubStatsExcludeDeletedEntries),
         RegressionCase(name: "time hub groups entries by client and project", run: timeHubGroupsEntriesByClientAndProject),
-        RegressionCase(name: "date and decimal formatting are stable across languages", run: dateAndDecimalFormattingAreStableAcrossLanguages)
+        RegressionCase(name: "date and decimal formatting are stable across languages", run: dateAndDecimalFormattingAreStableAcrossLanguages),
+        RegressionCase(name: "email template resolves placeholders and attachments line", run: emailTemplateResolvesPlaceholdersAndAttachmentsLine),
+        RegressionCase(name: "email safe filename strips unsafe characters", run: emailSafeFilenameStripsUnsafeCharacters),
+        RegressionCase(name: "attachment import copies file and records metadata", run: attachmentImportCopiesFileAndRecordsMetadata),
+        RegressionCase(name: "attachment duplication reports missing source files", run: attachmentDuplicationReportsMissingSourceFiles),
+        RegressionCase(name: "attachment urls expose only existing files", run: attachmentURLsExposeOnlyExistingFiles)
     ]
 
     private static func decimalHourInputKeepsDecimalFractions() throws {
@@ -1826,6 +1831,126 @@ enum FacioRegressionSuite {
         try expectEqual(amount.formatted2Decimals(for: .fr), "1 234,50")
         try expectEqual(amount.formatted2Decimals(for: .en), "1,234.50")
         try expectEqual(decimal("1234.6").formattedNoDecimals(for: .en), "1,235")
+    }
+
+    private static func emailTemplateResolvesPlaceholdersAndAttachmentsLine() throws {
+        let company = try JSONDecoder().decode(CompanyInfo.self, from: Data(#"{"nom":"Facio SAS"}"#.utf8))
+        let document = Document(type: .facture, number: "Facture_2026_07")
+        document.clientNom = "ACME Corp"
+
+        let template = """
+        Bonjour {client},
+
+        Facture {number} de {amount} avant le {due_date}.
+
+        {attachments}
+
+        Cordialement,
+        {company}
+        """
+
+        let withoutAttachments = EmailService.resolveTemplate(template, document: document, company: company)
+        try expect(withoutAttachments.contains("ACME Corp"), "client placeholder should be substituted")
+        try expect(withoutAttachments.contains("Facture_2026_07"), "number placeholder should be substituted")
+        try expect(withoutAttachments.contains("Facio SAS"), "company placeholder should be substituted")
+        try expect(!withoutAttachments.contains("{"), "no placeholder should remain unresolved")
+        try expect(!withoutAttachments.contains("\n\n\n"), "blank lines left by the empty attachments placeholder should collapse")
+
+        document.attachments = [
+            DocumentAttachment(originalFilename: "ticket.pdf", fileExtension: "pdf", label: "", fileSize: 10)
+        ]
+        let withAttachments = EmailService.resolveTemplate(template, document: document, company: company)
+        try expect(
+            withAttachments.contains(L10n.emailAttachmentsLine(document.langue)),
+            "attachments line should be inserted when the document has attachments"
+        )
+    }
+
+    private static func emailSafeFilenameStripsUnsafeCharacters() throws {
+        try expectEqual(EmailService.safeFilename("Facture/2026:03"), "Facture-2026-03")
+        try expectEqual(EmailService.safeFilename("  Devis 2026_04  "), "Devis 2026_04")
+        try expectEqual(EmailService.safeFilename("///"), "document")
+        try expectEqual(EmailService.safeFilename(""), "document")
+        try expectEqual(EmailService.safeFilename(String(repeating: "a", count: 200)).count, 120)
+    }
+
+    private static func attachmentImportCopiesFileAndRecordsMetadata() throws {
+        try withTemporaryDataStore { store in
+            let document = store.createDocument(type: .facture)
+            let source = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+                .appendingPathComponent("facio-attachment-\(UUID().uuidString).pdf")
+            try Data("pdf".utf8).write(to: source)
+            defer { try? FileManager.default.removeItem(at: source) }
+
+            let attachment = try require(
+                store.importAttachment(from: source, to: document, label: "Ticket"),
+                "importing an existing file should succeed"
+            )
+            try expectEqual(document.attachments.count, 1)
+            try expectEqual(attachment.originalFilename, source.lastPathComponent)
+            try expect(
+                FileManager.default.fileExists(atPath: store.attachmentURL(attachment, in: document).path),
+                "imported attachment file should exist in the document directory"
+            )
+
+            let missing = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+                .appendingPathComponent("facio-missing-\(UUID().uuidString).pdf")
+            try expect(store.importAttachment(from: missing, to: document) == nil, "importing a missing file should fail")
+            try expectEqual(document.attachments.count, 1)
+        }
+    }
+
+    private static func attachmentDuplicationReportsMissingSourceFiles() throws {
+        try withTemporaryDataStore { store in
+            let source = store.createDocument(type: .facture)
+            let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            let fileA = dir.appendingPathComponent("facio-kept-\(UUID().uuidString).pdf")
+            let fileB = dir.appendingPathComponent("facio-lost-\(UUID().uuidString).pdf")
+            try Data("a".utf8).write(to: fileA)
+            try Data("b".utf8).write(to: fileB)
+            defer {
+                try? FileManager.default.removeItem(at: fileA)
+                try? FileManager.default.removeItem(at: fileB)
+            }
+
+            let kept = try require(store.importAttachment(from: fileA, to: source), "first import should succeed")
+            let lost = try require(store.importAttachment(from: fileB, to: source), "second import should succeed")
+            try FileManager.default.removeItem(at: store.attachmentURL(lost, in: source))
+
+            let destination = source.dupliquer()
+            store.addDocument(destination)
+            let result = store.duplicateAttachments(from: source, to: destination)
+
+            try expectEqual(result.copied, 1)
+            try expectEqual(result.failed, 1)
+            try expectEqual(destination.attachments.count, 1)
+            try expectEqual(destination.attachments.first?.originalFilename, kept.originalFilename)
+            try expect(destination.attachments.first?.id != kept.id, "duplicated attachment should get a new identity")
+        }
+    }
+
+    private static func attachmentURLsExposeOnlyExistingFiles() throws {
+        try withTemporaryDataStore { store in
+            let document = store.createDocument(type: .facture)
+            let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            let fileA = dir.appendingPathComponent("facio-a-\(UUID().uuidString).pdf")
+            let fileB = dir.appendingPathComponent("facio-b-\(UUID().uuidString).pdf")
+            try Data("a".utf8).write(to: fileA)
+            try Data("b".utf8).write(to: fileB)
+            defer {
+                try? FileManager.default.removeItem(at: fileA)
+                try? FileManager.default.removeItem(at: fileB)
+            }
+
+            let stays = try require(store.importAttachment(from: fileA, to: document), "first import should succeed")
+            let removed = try require(store.importAttachment(from: fileB, to: document), "second import should succeed")
+            try FileManager.default.removeItem(at: store.attachmentURL(removed, in: document))
+
+            let urls = store.attachmentURLs(for: document)
+            try expectEqual(urls.count, 1)
+            try expectEqual(urls.first, store.attachmentURL(stays, in: document))
+            try expectEqual(document.attachments.count, 2)
+        }
     }
 
     private static func withTemporaryDataStore(_ body: (DataStore) throws -> Void) throws {

--- a/Facio/Localization/L10n+Email.swift
+++ b/Facio/Localization/L10n+Email.swift
@@ -13,8 +13,30 @@ extension L10n {
     static func dropAttachmentHere(_ l: AppLanguage) -> String { l == .fr ? "Déposez vos fichiers ici" : "Drop your files here" }
     static func attachmentLabelPlaceholder(_ l: AppLanguage) -> String { l == .fr ? "Libellé (ex. Train Nancy⇄Paris)" : "Label (e.g. Train Nancy⇄Paris)" }
     static func openAttachment(_ l: AppLanguage) -> String { l == .fr ? "Ouvrir" : "Open" }
-    static func attachmentImportFailed(_ l: AppLanguage) -> String {
-        l == .fr ? "Impossible d'importer ce fichier." : "Could not import this file."
+    static func attachmentImportFailedCount(_ l: AppLanguage, count: Int) -> String {
+        if l == .fr {
+            return count == 1
+                ? "Impossible d'importer ce fichier."
+                : "Impossible d'importer \(count) fichiers."
+        }
+        return count == 1
+            ? "Could not import this file."
+            : "Could not import \(count) files."
+    }
+
+    // Échec de copie des justificatifs lors d'une duplication / conversion
+    static func attachmentsCopyFailedTitle(_ l: AppLanguage) -> String {
+        l == .fr ? "Justificatifs non copiés" : "Supporting documents not copied"
+    }
+    static func attachmentsCopyFailedMessage(_ l: AppLanguage, count: Int) -> String {
+        if l == .fr {
+            return count == 1
+                ? "1 justificatif n'a pas pu être copié vers le nouveau document (fichier introuvable ou copie impossible)."
+                : "\(count) justificatifs n'ont pas pu être copiés vers le nouveau document (fichiers introuvables ou copie impossible)."
+        }
+        return count == 1
+            ? "1 supporting document could not be copied to the new document (missing file or copy failure)."
+            : "\(count) supporting documents could not be copied to the new document (missing files or copy failure)."
     }
 
     // Envoi par email

--- a/Facio/Services/DataStore.swift
+++ b/Facio/Services/DataStore.swift
@@ -511,15 +511,21 @@ final class DataStore: Sendable {
     }
 
     /// Copie les justificatifs d'un document vers un autre (nouveaux ids/fichiers).
-    /// Utilisé lors de la duplication d'un document.
-    func duplicateAttachments(from source: Document, to destination: Document) {
-        guard !source.attachments.isEmpty else { return }
+    /// Utilisé lors de la duplication d'un document. Retourne le nombre de copies
+    /// réussies et échouées (fichier source manquant ou copie impossible) pour
+    /// que l'appelant puisse signaler les pertes.
+    func duplicateAttachments(from source: Document, to destination: Document) -> (copied: Int, failed: Int) {
+        guard !source.attachments.isEmpty else { return (0, 0) }
         let destDir = attachmentsDirectory(for: destination.id)
         try? SecurePersistence.ensureStorageDirectory(at: destDir)
         var copied: [DocumentAttachment] = []
+        var failed = 0
         for attachment in source.attachments {
             let sourceFile = attachmentURL(attachment, in: source)
-            guard fileManager.fileExists(atPath: sourceFile.path) else { continue }
+            guard fileManager.fileExists(atPath: sourceFile.path) else {
+                failed += 1
+                continue
+            }
             var copy = attachment
             copy.id = UUID()
             let destFile = destDir.appendingPathComponent(copy.storedFilename)
@@ -528,11 +534,12 @@ final class DataStore: Sendable {
                 try? SecurePersistence.hardenFile(at: destFile)
                 copied.append(copy)
             } catch {
-                continue
+                failed += 1
             }
         }
         destination.attachments = copied
         saveDocuments()
+        return (copied.count, failed)
     }
 
     // MARK: - Client CRUD

--- a/Facio/Services/EmailService.swift
+++ b/Facio/Services/EmailService.swift
@@ -59,8 +59,10 @@ enum EmailService {
             return .unavailable
         }
 
+        // Re-vérifie l'existence au dernier moment : un justificatif peut avoir
+        // été supprimé entre la construction des URLs et l'ouverture du composer.
         var items: [Any] = [body, pdfURL]
-        items.append(contentsOf: attachmentURLs)
+        items.append(contentsOf: attachmentURLs.filter { FileManager.default.fileExists(atPath: $0.path) })
 
         guard let service = NSSharingService(named: .composeEmail),
               service.canPerform(withItems: items) else {
@@ -76,13 +78,13 @@ enum EmailService {
 
         // Nettoyage différé : le composer lit le fichier de façon asynchrone,
         // on ne peut donc pas le supprimer immédiatement après perform().
-        DispatchQueue.main.asyncAfter(deadline: .now() + 300) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 90) {
             try? FileManager.default.removeItem(at: tempDir)
         }
         return .composed
     }
 
-    private static func safeFilename(_ base: String) -> String {
+    static func safeFilename(_ base: String) -> String {
         let cleaned = base.unicodeScalars.map { scalar -> Character in
             if CharacterSet.alphanumerics.contains(scalar)
                 || CharacterSet(charactersIn: " ._-").contains(scalar) {

--- a/Facio/Views/Documents/DocumentAttachmentsSection.swift
+++ b/Facio/Views/Documents/DocumentAttachmentsSection.swift
@@ -11,7 +11,7 @@ struct DocumentAttachmentsSection: View {
     @Environment(DataStore.self) private var dataStore
 
     @State private var isDropTargeted = false
-    @State private var importError: String?
+    @State private var failedImportCount = 0
 
     var body: some View {
         SectionPanel(L10n.attachmentsSection(lang), systemImage: "paperclip") {
@@ -40,8 +40,8 @@ struct DocumentAttachmentsSection: View {
 
                 dropZone
 
-                if let importError {
-                    InlineWarning(text: importError, tone: .danger)
+                if failedImportCount > 0 {
+                    InlineWarning(text: L10n.attachmentImportFailedCount(lang, count: failedImportCount), tone: .danger)
                 }
 
                 Button {
@@ -90,14 +90,14 @@ struct DocumentAttachmentsSection: View {
         panel.allowsMultipleSelection = true
         panel.canChooseDirectories = false
         guard panel.runModal() == .OK else { return }
-        importError = nil
+        failedImportCount = 0
         for url in panel.urls where dataStore.importAttachment(from: url, to: document) == nil {
-            importError = L10n.attachmentImportFailed(lang)
+            failedImportCount += 1
         }
     }
 
     private func handleDrop(_ providers: [NSItemProvider]) -> Bool {
-        importError = nil
+        failedImportCount = 0
         var handledAny = false
         for provider in providers where provider.hasItemConformingToTypeIdentifier("public.file-url") {
             handledAny = true
@@ -106,11 +106,11 @@ struct DocumentAttachmentsSection: View {
                       let url = URL(dataRepresentation: data, relativeTo: nil) else { return }
                 DispatchQueue.main.async {
                     guard Self.allowedExtensions.contains(url.pathExtension.lowercased()) else {
-                        importError = L10n.attachmentImportFailed(lang)
+                        failedImportCount += 1
                         return
                     }
                     if dataStore.importAttachment(from: url, to: document) == nil {
-                        importError = L10n.attachmentImportFailed(lang)
+                        failedImportCount += 1
                     }
                 }
             }
@@ -169,7 +169,7 @@ private struct AttachmentRowView: View {
         .padding(.vertical, FacioLayout.space4)
         .onAppear { labelText = attachment.label }
         .onChange(of: attachment.label) { _, newValue in
-            if !labelFocused { labelText = newValue }
+            if !labelFocused && labelText != newValue { labelText = newValue }
         }
     }
 

--- a/Facio/Views/Documents/DocumentEditorView.swift
+++ b/Facio/Views/Documents/DocumentEditorView.swift
@@ -10,6 +10,8 @@ struct DocumentEditorView: View {
     @State private var showAddSignature = false
     @State private var showPDFGenerationAlert = false
     @State private var showPDFExportAlert = false
+    @State private var attachmentCopyFailures = 0
+    @State private var showAttachmentCopyAlert = false
     @State private var showEmailUnavailableAlert = false
     @State private var signatureCountBeforeSheet = 0
 
@@ -111,6 +113,11 @@ struct DocumentEditorView: View {
             Button(L10n.understood(lang), role: .cancel) {}
         } message: {
             Text(L10n.emailUnavailableMessage(lang))
+        }
+        .alert(L10n.attachmentsCopyFailedTitle(lang), isPresented: $showAttachmentCopyAlert) {
+            Button(L10n.understood(lang), role: .cancel) {}
+        } message: {
+            Text(L10n.attachmentsCopyFailedMessage(lang, count: attachmentCopyFailures))
         }
     }
 
@@ -754,7 +761,7 @@ struct DocumentEditorView: View {
             language: lang
         )
         dataStore.addDocument(copie)
-        dataStore.duplicateAttachments(from: document, to: copie)
+        reportCopyFailures(dataStore.duplicateAttachments(from: document, to: copie))
     }
 
     private func convertirEnFacture() {
@@ -765,7 +772,13 @@ struct DocumentEditorView: View {
             language: lang
         )
         dataStore.addDocument(facture)
-        dataStore.duplicateAttachments(from: document, to: facture)
+        reportCopyFailures(dataStore.duplicateAttachments(from: document, to: facture))
+    }
+
+    private func reportCopyFailures(_ result: (copied: Int, failed: Int)) {
+        guard result.failed > 0 else { return }
+        attachmentCopyFailures = result.failed
+        showAttachmentCopyAlert = true
     }
 
     private func exporterPDF() {

--- a/Facio/Views/Documents/DocumentListView.swift
+++ b/Facio/Views/Documents/DocumentListView.swift
@@ -8,6 +8,8 @@ struct DocumentListView: View {
     @Environment(DataStore.self) private var dataStore
     @State private var searchText = ""
     @State private var documentPendingDeletion: Document?
+    @State private var attachmentCopyFailures = 0
+    @State private var showAttachmentCopyAlert = false
 
     private var lang: AppLanguage { dataStore.companyInfo.langueParDefaut }
 
@@ -108,6 +110,11 @@ struct DocumentListView: View {
                 number: documentPendingDeletion?.number ?? ""
             ))
         }
+        .alert(L10n.attachmentsCopyFailedTitle(lang), isPresented: $showAttachmentCopyAlert) {
+            Button(L10n.understood(lang), role: .cancel) {}
+        } message: {
+            Text(L10n.attachmentsCopyFailedMessage(lang, count: attachmentCopyFailures))
+        }
     }
 
     // MARK: - Actions
@@ -132,7 +139,7 @@ struct DocumentListView: View {
             language: lang
         )
         dataStore.addDocument(copie)
-        dataStore.duplicateAttachments(from: document, to: copie)
+        reportCopyFailures(dataStore.duplicateAttachments(from: document, to: copie))
         selectedDocumentId = copie.id
     }
 
@@ -144,8 +151,14 @@ struct DocumentListView: View {
             language: lang
         )
         dataStore.addDocument(facture)
-        dataStore.duplicateAttachments(from: document, to: facture)
+        reportCopyFailures(dataStore.duplicateAttachments(from: document, to: facture))
         onOpenDocument(facture)
+    }
+
+    private func reportCopyFailures(_ result: (copied: Int, failed: Int)) {
+        guard result.failed > 0 else { return }
+        attachmentCopyFailures = result.failed
+        showAttachmentCopyAlert = true
     }
 
 }

--- a/Facio/Views/Settings/EmailSettingsView.swift
+++ b/Facio/Views/Settings/EmailSettingsView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct EmailSettingsView: View {
     @Environment(DataStore.self) private var dataStore
     @State private var templateLang: AppLanguage = .fr
+    @State private var hasInitializedTemplateLang = false
 
     private var company: CompanyInfo { dataStore.companyInfo }
     private var lang: AppLanguage { dataStore.companyInfo.langueParDefaut }
@@ -55,7 +56,13 @@ struct EmailSettingsView: View {
             Spacer()
         }
         .padding(FacioLayout.screenPadding)
-        .onAppear { templateLang = dataStore.companyInfo.langueParDefaut }
+        .onAppear {
+            // Seule la première apparition initialise la langue : un onAppear
+            // ultérieur ne doit pas écraser la sélection en cours de l'utilisateur.
+            guard !hasInitializedTemplateLang else { return }
+            hasInitializedTemplateLang = true
+            templateLang = dataStore.companyInfo.langueParDefaut
+        }
     }
 
     // Le champ affiche le modèle par défaut tant qu'il n'est pas personnalisé.


### PR DESCRIPTION
## Contexte

PR1 du chantier UI/UX (plan validé) : fixes ciblés sur la feature justificatifs + envoi email (#78), indépendants du reste du chantier.

## Changements

- **EmailService** : nettoyage du dossier temporaire ramené de 300 s à 90 s ; les URLs de justificatifs sont re-vérifiées au dernier moment avant l'ouverture du composer (un fichier supprimé entre-temps n'est plus transmis).
- **DataStore.duplicateAttachments** retourne désormais `(copied, failed)` — plus de `try?` silencieux qui perdait des justificatifs sans signalement.
- **Éditeur ET liste de documents** : dupliquer / convertir en facture affichent une alerte « Justificatifs non copiés » quand des copies échouent (même comportement quel que soit le point d'entrée).
- **Import de justificatifs** : les erreurs sont agrégées en un seul message avec compteur (« Impossible d'importer N fichiers ») au lieu d'un message écrasé par fichier.
- **Libellé de justificatif** : garde anti-réécriture dans le `onChange` (pas de réassignation si la valeur est identique).
- **Réglages email** : la langue du modèle n'est initialisée qu'à la première apparition — un retour sur l'onglet n'écrase plus la sélection en cours.
- Nouvelles chaînes L10n en FR **et** EN.

## Tests

`chore(tests):` 5 nouveaux cas RegressionSuite : substitution du modèle d'email (+ ligne justificatifs), `safeFilename`, import (succès/échec), duplication avec fichier source manquant, filtrage des URLs manquantes.

## Vérification

- `swift build` : 0 erreur, 0 warning.
- `.build/debug/Facio --run-regressions` : **76/76 verts**.
- Revue adversariale multi-agents passée sur le diff ; le finding confirmé (liste de documents sans alerte) a été corrigé avant commit.