### PR TITLE
refactor(design): adoption complète du design system

### DIFF
--- a/Facio/FacioApp.swift
+++ b/Facio/FacioApp.swift
@@ -33,6 +33,8 @@ struct FacioApp: App {
                 .environment(syncService)
                 .environment(authService)
                 .environment(networkMonitor)
+                .environment(\.facioAccent, Color.appPrimary(from: dataStore.companyInfo))
+                .tint(Color.appPrimary(from: dataStore.companyInfo))
                 .frame(minWidth: FacioLayout.windowMinWidth, minHeight: FacioLayout.windowMinHeight)
                 .alert(L10n.firstLaunchTitle(lang), isPresented: $showFirstLaunch) {
                     Button(L10n.understood(lang)) {
@@ -93,6 +95,8 @@ struct FacioApp: App {
                 .environment(dataStore)
                 .environment(syncService)
                 .environment(authService)
+                .environment(\.facioAccent, Color.appPrimary(from: dataStore.companyInfo))
+                .tint(Color.appPrimary(from: dataStore.companyInfo))
         }
     }
 }

--- a/Facio/Localization/L10n+Documents.swift
+++ b/Facio/Localization/L10n+Documents.swift
@@ -42,6 +42,11 @@ extension L10n {
     static func quantityLabel(_ l: AppLanguage) -> String { l == .fr ? "Quantité" : "Quantity" }
     static func unitPrice(_ l: AppLanguage) -> String { l == .fr ? "Prix unitaire" : "Unit price" }
     static func vatLabel(_ l: AppLanguage) -> String { l == .fr ? "TVA" : "VAT" }
+    /// Taux de TVA formaté selon le format de nombre (« 5,5 % » / « 5.5% »).
+    static func vatRateLabel(_ l: AppLanguage, rate: Decimal) -> String {
+        let value = rate.formattedDecimal(maxFractionDigits: 2, for: l)
+        return l == .fr ? "\(value) %" : "\(value)%"
+    }
     static func totalHTLabel(_ l: AppLanguage) -> String { l == .fr ? "Total HT" : "Subtotal" }
     static func priceLabel(_ l: AppLanguage) -> String { l == .fr ? "Prix" : "Price" }
     static func qtyShort(_ l: AppLanguage) -> String { l == .fr ? "Qte" : "Qty" }

--- a/Facio/Views/Clients/ClientListView.swift
+++ b/Facio/Views/Clients/ClientListView.swift
@@ -177,7 +177,7 @@ struct ClientRow: View {
                     .joined(separator: " ")
                 if !address.isEmpty {
                     Text(address)
-                        .font(.caption)
+                        .font(FacioFont.caption)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
                 }
@@ -188,7 +188,7 @@ struct ClientRow: View {
                 ].compactMap { $0 }
                 if !identifiers.isEmpty {
                     Text(identifiers.joined(separator: " - "))
-                        .font(.caption2)
+                        .font(FacioFont.captionSmall)
                         .foregroundStyle(.tertiary)
                         .lineLimit(1)
                 }
@@ -261,11 +261,10 @@ struct ClientDetailView: View {
         HStack {
             VStack(alignment: .leading, spacing: FacioLayout.space4) {
                 Text(client.displayName.isEmpty ? L10n.noClient(lang) : client.displayName)
-                    .font(.largeTitle)
-                    .fontWeight(.bold)
+                    .font(FacioFont.screenTitle)
                 if !client.email.isEmpty {
                     Text(client.email)
-                        .font(.subheadline)
+                        .font(FacioFont.screenSubtitle)
                         .foregroundStyle(.secondary)
                         .textSelection(.enabled)
                 }
@@ -307,14 +306,14 @@ struct ClientDetailView: View {
                 } label: {
                     Label(L10n.createInvoiceForClient(lang), systemImage: "doc.text")
                 }
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(.facio(.primary))
 
                 Button {
                     onCreateDocument(.devis, client)
                 } label: {
                     Label(L10n.createQuoteForClient(lang), systemImage: "doc.text.magnifyingglass")
                 }
-                .buttonStyle(.bordered)
+                .buttonStyle(.facio(.secondary))
 
                 Spacer()
             }
@@ -326,40 +325,40 @@ struct ClientDetailView: View {
             VStack(alignment: .leading, spacing: FacioLayout.space12) {
                 LabeledField(L10n.name(lang)) {
                     TextField(L10n.name(lang), text: Bindable(client).nom)
-                        .textFieldStyle(.roundedBorder)
+                        .facioField()
                 }
                 LabeledField(L10n.address(lang)) {
                     TextField(L10n.address(lang), text: Bindable(client).adresse)
-                        .textFieldStyle(.roundedBorder)
+                        .facioField()
                 }
                 HStack(spacing: FacioLayout.space12) {
                     LabeledField(L10n.postalCode(lang)) {
                         TextField(L10n.postalCode(lang), text: Bindable(client).codePostal)
-                            .textFieldStyle(.roundedBorder)
+                            .facioField()
                     }
                     .frame(maxWidth: 140)
 
                     LabeledField(L10n.city(lang)) {
                         TextField(L10n.city(lang), text: Bindable(client).ville)
-                            .textFieldStyle(.roundedBorder)
+                            .facioField()
                     }
                 }
                 LabeledField(L10n.email(lang)) {
                     TextField(L10n.email(lang), text: Bindable(client).email)
-                        .textFieldStyle(.roundedBorder)
+                        .facioField()
                 }
                 HStack(spacing: FacioLayout.space12) {
                     LabeledField(L10n.siret(lang)) {
                         TextField(L10n.clientSiretPlaceholder(lang), text: Bindable(client).siret)
-                            .textFieldStyle(.roundedBorder)
+                            .facioField()
                     }
                     LabeledField(L10n.vatNumber(lang)) {
                         TextField(L10n.clientTvaPlaceholder(lang), text: Bindable(client).tva)
-                            .textFieldStyle(.roundedBorder)
+                            .facioField()
                     }
                     LabeledField(L10n.apeCode(lang)) {
                         TextField(L10n.apeCode(lang), text: Bindable(client).ape)
-                            .textFieldStyle(.roundedBorder)
+                            .facioField()
                     }
                 }
             }
@@ -397,13 +396,12 @@ struct ClientDetailView: View {
                     Text(document.number)
                         .fontWeight(.medium)
                     Text(document.dateCreation.formattedDate(for: dataStore.companyInfo.formatDate))
-                        .font(.caption)
+                        .font(FacioFont.caption)
                         .foregroundStyle(.secondary)
                 }
                 Spacer()
                 Text(document.currency.formatAccounting(document.totalTTC, lang: numberFormat))
-                    .font(.body.monospacedDigit())
-                    .fontWeight(.medium)
+                    .font(FacioFont.amount)
                 StatusBadge(status: document.status, isOverdue: document.isOverdue)
                 Image(systemName: "chevron.right")
                     .font(.caption)

--- a/Facio/Views/CommandPaletteView.swift
+++ b/Facio/Views/CommandPaletteView.swift
@@ -236,9 +236,9 @@ struct CommandPaletteView: View {
                 }
 
                 TextField(L10n.commandPalettePlaceholder(lang), text: $searchText)
-                    .textFieldStyle(.roundedBorder)
                     .focused($searchFocused)
                     .onSubmit { runSelected() }
+                    .facioField()
             }
             .padding(18)
 

--- a/Facio/Views/CommandPaletteView.swift
+++ b/Facio/Views/CommandPaletteView.swift
@@ -229,7 +229,7 @@ struct CommandPaletteView: View {
             VStack(alignment: .leading, spacing: FacioLayout.space12) {
                 HStack {
                     Label(L10n.commandPaletteTitle(lang), systemImage: "command")
-                        .font(.headline)
+                        .font(FacioFont.sectionTitle)
                     Spacer()
                     Button(L10n.close(lang)) { dismiss() }
                         .keyboardShortcut(.cancelAction)
@@ -317,7 +317,7 @@ struct CommandPaletteView: View {
     private func paletteSection<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
         VStack(alignment: .leading, spacing: FacioLayout.space8) {
             Text(title)
-                .font(.caption)
+                .font(FacioFont.caption)
                 .fontWeight(.semibold)
                 .foregroundStyle(.secondary)
                 .textCase(.uppercase)
@@ -338,7 +338,7 @@ struct CommandPaletteView: View {
                     .lineLimit(1)
                 if !subtitle.isEmpty {
                     Text(subtitle)
-                        .font(.caption)
+                        .font(FacioFont.caption)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
                 }

--- a/Facio/Views/Components/DesignSystem.swift
+++ b/Facio/Views/Components/DesignSystem.swift
@@ -111,6 +111,29 @@ enum InlineTone {
 
 // MARK: - Panels & cards
 
+/// Chrome partagé des panneaux et tuiles : fond, bordure discrète, coins arrondis.
+/// Remplace les blocs `background + overlay + clipShape` dupliqués dans les vues.
+struct FacioCardChrome: ViewModifier {
+    var surface: Color = .surfacePanel
+    var radius: CGFloat = FacioLayout.radiusPanel
+
+    func body(content: Content) -> some View {
+        content
+            .background(surface)
+            .overlay(
+                RoundedRectangle(cornerRadius: radius)
+                    .strokeBorder(Color.borderSubtle, lineWidth: 1)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: radius))
+    }
+}
+
+extension View {
+    func facioCardChrome(surface: Color = .surfacePanel, radius: CGFloat = FacioLayout.radiusPanel) -> some View {
+        modifier(FacioCardChrome(surface: surface, radius: radius))
+    }
+}
+
 struct SectionPanel<Content: View>: View {
     let title: String?
     let systemImage: String?
@@ -134,12 +157,7 @@ struct SectionPanel<Content: View>: View {
         }
         .padding(FacioLayout.panelPadding)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(Color.surfacePanel)
-        .overlay(
-            RoundedRectangle(cornerRadius: FacioLayout.radiusPanel)
-                .strokeBorder(Color.borderSubtle, lineWidth: 1)
-        )
-        .clipShape(RoundedRectangle(cornerRadius: FacioLayout.radiusPanel))
+        .facioCardChrome()
     }
 }
 
@@ -198,12 +216,7 @@ struct MetricTile: View {
         }
         .padding(FacioLayout.tilePadding)
         .frame(maxWidth: .infinity, minHeight: 128, maxHeight: 148, alignment: .topLeading)
-        .background(Color.surfaceTile)
-        .overlay(
-            RoundedRectangle(cornerRadius: FacioLayout.radiusPanel)
-                .strokeBorder(Color.borderSubtle, lineWidth: 1)
-        )
-        .clipShape(RoundedRectangle(cornerRadius: FacioLayout.radiusPanel))
+        .facioCardChrome(surface: .surfaceTile)
     }
 }
 

--- a/Facio/Views/Components/FacioButton.swift
+++ b/Facio/Views/Components/FacioButton.swift
@@ -10,12 +10,30 @@ enum FacioButtonRole {
     case destructive
 }
 
+/// Accent de marque ambiant (couleur d'accent de `CompanyInfo`), injecté à la
+/// racine de chaque scène par `FacioApp`. Permet aux styles de boutons de
+/// suivre la couleur de marque sans dépendre de `DataStore`.
+private struct FacioAccentKey: EnvironmentKey {
+    // `static var` calculée : même précaution que Color+Theme (crash du
+    // compilateur Swift 6.0.x en release sur les `static let` de Color).
+    static var defaultValue: Color { .appPrimary }
+}
+
+extension EnvironmentValues {
+    var facioAccent: Color {
+        get { self[FacioAccentKey.self] }
+        set { self[FacioAccentKey.self] = newValue }
+    }
+}
+
 /// Style de bouton tokenisé. Utilisable via `.buttonStyle(.facio(.primary))`.
+/// Sans `accent` explicite, le style suit l'accent de marque ambiant.
 struct FacioButtonStyle: ButtonStyle {
     var role: FacioButtonRole = .primary
-    var accent: Color = .appPrimary
+    var accent: Color? = nil
 
     @Environment(\.isEnabled) private var isEnabled
+    @Environment(\.facioAccent) private var ambientAccent
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
@@ -37,7 +55,7 @@ struct FacioButtonStyle: ButtonStyle {
 
     private var fill: Color {
         switch role {
-        case .primary: return accent
+        case .primary: return accent ?? ambientAccent
         case .secondary: return .surfaceTile
         case .destructive: return .intentDanger
         }
@@ -68,15 +86,13 @@ struct FacioButtonStyle: ButtonStyle {
 }
 
 extension ButtonStyle where Self == FacioButtonStyle {
-    static func facio(_ role: FacioButtonRole = .primary, accent: Color = .appPrimary) -> FacioButtonStyle {
+    static func facio(_ role: FacioButtonRole = .primary, accent: Color? = nil) -> FacioButtonStyle {
         FacioButtonStyle(role: role, accent: accent)
     }
 }
 
-/// Bouton prêt à l'emploi câblé sur l'accent de marque dynamique (depuis `CompanyInfo`).
+/// Bouton prêt à l'emploi suivant l'accent de marque ambiant.
 struct FacioButton: View {
-    @Environment(DataStore.self) private var dataStore
-
     let title: String
     var systemImage: String?
     var role: FacioButtonRole = .primary
@@ -97,7 +113,7 @@ struct FacioButton: View {
                 Text(title)
             }
         }
-        .buttonStyle(.facio(role, accent: .appPrimary(from: dataStore.companyInfo)))
+        .buttonStyle(.facio(role))
     }
 }
 

--- a/Facio/Views/Components/FacioTextField.swift
+++ b/Facio/Views/Components/FacioTextField.swift
@@ -1,41 +1,38 @@
 import SwiftUI
 
-/// Champ de saisie tokenisé avec erreur **visible inline** (et non en tooltip).
-///
-/// Remplace les `TextField().textFieldStyle(.roundedBorder)` répétés et offre
-/// un état focus et un état d'erreur explicites.
-struct FacioTextField: View {
-    let placeholder: String
-    @Binding var text: String
-    var systemImage: String?
+/// Densité du chrome d'un champ : `regular` pour les formulaires,
+/// `compact` pour les lignes de tableau et les barres de saisie denses.
+enum FacioFieldDensity {
+    case regular
+    case compact
+}
+
+/// Chrome tokenisé d'un champ de saisie, appliqué à un `TextField`/`SecureField`
+/// natif via `.facioField(error:density:)` : fond `surfaceField`, bordure avec
+/// états focus/erreur, et message d'erreur inline en densité `regular` (en
+/// `compact`, seule la bordure signale l'erreur pour ne pas casser la hauteur
+/// des lignes). Source unique du style de champ — `FacioTextField` s'appuie dessus.
+struct FacioFieldModifier: ViewModifier {
     var error: String?
-    var alignment: TextAlignment = .leading
+    var density: FacioFieldDensity = .regular
 
     @FocusState private var isFocused: Bool
 
-    var body: some View {
+    func body(content: Content) -> some View {
         VStack(alignment: .leading, spacing: FacioLayout.space4) {
-            HStack(spacing: FacioLayout.space8) {
-                if let systemImage {
-                    Image(systemName: systemImage)
-                        .foregroundStyle(.secondary)
-                        .font(.caption)
-                }
-                TextField(placeholder, text: $text)
-                    .textFieldStyle(.plain)
-                    .multilineTextAlignment(alignment)
-                    .focused($isFocused)
-            }
-            .padding(.horizontal, FacioLayout.space10)
-            .padding(.vertical, FacioLayout.space8)
-            .background(Color.surfaceField)
-            .overlay(
-                RoundedRectangle(cornerRadius: FacioLayout.radiusField)
-                    .strokeBorder(borderColor, lineWidth: 1)
-            )
-            .clipShape(RoundedRectangle(cornerRadius: FacioLayout.radiusField))
+            content
+                .textFieldStyle(.plain)
+                .focused($isFocused)
+                .padding(.horizontal, density == .regular ? FacioLayout.space10 : FacioLayout.space8)
+                .padding(.vertical, density == .regular ? FacioLayout.space8 : FacioLayout.space4)
+                .background(Color.surfaceField)
+                .overlay(
+                    RoundedRectangle(cornerRadius: FacioLayout.radiusField)
+                        .strokeBorder(borderColor, lineWidth: 1)
+                )
+                .clipShape(RoundedRectangle(cornerRadius: FacioLayout.radiusField))
 
-            if let error, !error.isEmpty {
+            if density == .regular, let error, !error.isEmpty {
                 Text(error)
                     .font(FacioFont.captionSmall)
                     .foregroundStyle(Color.intentDanger)
@@ -47,5 +44,38 @@ struct FacioTextField: View {
     private var borderColor: Color {
         if error?.isEmpty == false { return .intentDanger }
         return isFocused ? .borderHover : .borderSubtle
+    }
+}
+
+extension View {
+    /// Applique le chrome de champ du design system à un champ de saisie natif.
+    /// Remplace les `.textFieldStyle(.roundedBorder)` disséminés dans les vues.
+    func facioField(error: String? = nil, density: FacioFieldDensity = .regular) -> some View {
+        modifier(FacioFieldModifier(error: error, density: density))
+    }
+}
+
+/// Champ de saisie tokenisé avec erreur **visible inline** (et non en tooltip).
+///
+/// Variante « riche » du chrome `.facioField` pour les cas avec icône d'appoint ;
+/// pour un champ nu, appliquer directement `.facioField()` au `TextField` natif.
+struct FacioTextField: View {
+    let placeholder: String
+    @Binding var text: String
+    var systemImage: String?
+    var error: String?
+    var alignment: TextAlignment = .leading
+
+    var body: some View {
+        HStack(spacing: FacioLayout.space8) {
+            if let systemImage {
+                Image(systemName: systemImage)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+            TextField(placeholder, text: $text)
+                .multilineTextAlignment(alignment)
+        }
+        .facioField(error: error)
     }
 }

--- a/Facio/Views/Components/FacioTypography.swift
+++ b/Facio/Views/Components/FacioTypography.swift
@@ -7,6 +7,13 @@ import SwiftUI
 /// d'Apple (Dynamic Type) quand c'est possible, et n'utilisent une taille fixe
 /// que pour les grands nombres (KPI, horloge de timer) où la mise à l'échelle
 /// casserait l'alignement.
+///
+/// Liste blanche — seuls cas où un `.font()` natif reste autorisé dans les vues :
+/// 1. dimensionnement d'un glyphe SF Symbol (`Image(systemName:).font(...)`) ;
+/// 2. tailles décoratives uniques (logo de la page À propos, « F » de repli) ;
+/// 3. le champ « héros » du numéro de document (borderless intentionnel) ;
+/// 4. libellés de boutons à chrome custom (.plain) sans token iso-sémantique.
+/// Tout autre `.font()` natif est une dette : le migrer vers un token.
 enum FacioFont {
     // MARK: - Titres
 

--- a/Facio/Views/Components/FacioTypography.swift
+++ b/Facio/Views/Components/FacioTypography.swift
@@ -18,12 +18,24 @@ enum FacioFont {
     /// Titre de section / de panneau (SectionPanel).
     static let sectionTitle: Font = .headline
 
+    /// Titre d'une sous-section à l'intérieur d'un panneau.
+    static let subsectionTitle: Font = .subheadline.weight(.semibold)
+
+    // MARK: - Formulaires
+
+    /// Libellé d'un champ de formulaire (LabeledField).
+    static let fieldLabel: Font = .subheadline
+
     // MARK: - Lignes & listes
 
     /// Titre d'une ligne de liste.
     static let rowTitle: Font = .subheadline.weight(.medium)
     /// Sous-titre / métadonnée d'une ligne.
     static let rowSubtitle: Font = .caption
+    /// Valeur numérique d'une ligne de liste.
+    static let rowValue: Font = .subheadline.monospacedDigit()
+    /// Métadonnée numérique discrète (compteurs, totaux secondaires).
+    static let metaValue: Font = .caption.monospacedDigit()
 
     // MARK: - Corps & légendes
 

--- a/Facio/Views/Components/FacioTypography.swift
+++ b/Facio/Views/Components/FacioTypography.swift
@@ -11,7 +11,8 @@ import SwiftUI
 /// Liste blanche — seuls cas où un `.font()` natif reste autorisé dans les vues :
 /// 1. dimensionnement d'un glyphe SF Symbol (`Image(systemName:).font(...)`) ;
 /// 2. tailles décoratives uniques (logo de la page À propos, « F » de repli) ;
-/// 3. le champ « héros » du numéro de document (borderless intentionnel) ;
+/// 3. le style `.plain` du champ « héros » du numéro de document et la taille
+///    `.title3` des champs de description du timer (mises en avant volontaires) ;
 /// 4. libellés de boutons à chrome custom (.plain) sans token iso-sémantique.
 /// Tout autre `.font()` natif est une dette : le migrer vers un token.
 enum FacioFont {
@@ -27,6 +28,11 @@ enum FacioFont {
 
     /// Titre d'une sous-section à l'intérieur d'un panneau.
     static let subsectionTitle: Font = .subheadline.weight(.semibold)
+
+    /// Titre « héros » d'un éditeur (numéro de document, période de timesheet).
+    static let heroTitle: Font = .title2.weight(.semibold)
+    /// Total TTC héros de l'éditeur de document.
+    static let heroTotal: Font = .title.monospacedDigit().weight(.bold)
 
     // MARK: - Formulaires
 

--- a/Facio/Views/Components/LabeledField.swift
+++ b/Facio/Views/Components/LabeledField.swift
@@ -16,7 +16,7 @@ struct LabeledField<Content: View>: View {
     var body: some View {
         VStack(alignment: .leading, spacing: FacioLayout.space4) {
             Text(label)
-                .font(.subheadline)
+                .font(FacioFont.fieldLabel)
                 .foregroundStyle(.secondary)
             content
         }

--- a/Facio/Views/Components/TimeField.swift
+++ b/Facio/Views/Components/TimeField.swift
@@ -28,19 +28,13 @@ struct TimeField: View {
 
     var body: some View {
         TextField(placeholder, text: $text)
-            .textFieldStyle(.roundedBorder)
             .multilineTextAlignment(.trailing)
             .focused($isFocused)
-            .frame(maxWidth: .infinity, minHeight: 28)
+            .frame(maxWidth: .infinity, minHeight: 20)
+            .facioField(error: validationError, density: .compact)
             .contentShape(Rectangle())
             .onTapGesture {
                 isFocused = true
-            }
-            .overlay {
-                if validationError != nil {
-                    RoundedRectangle(cornerRadius: FacioLayout.radiusField)
-                        .stroke(Color.intentDanger, lineWidth: 1)
-                }
             }
             .help(validationError ?? L10n.hourInputHelp(lang, mode: mode))
             .onAppear {

--- a/Facio/Views/Dashboard/DashboardView.swift
+++ b/Facio/Views/Dashboard/DashboardView.swift
@@ -144,10 +144,9 @@ struct DashboardView: View {
         HStack(alignment: .top, spacing: FacioLayout.space16) {
             VStack(alignment: .leading, spacing: FacioLayout.space4) {
                 Text(L10n.dashboard(lang))
-                    .font(.largeTitle)
-                    .fontWeight(.bold)
+                    .font(FacioFont.screenTitle)
                 Text(L10n.dashboardSubtitle(lang))
-                    .font(.subheadline)
+                    .font(FacioFont.screenSubtitle)
                     .foregroundStyle(.secondary)
             }
             Spacer()
@@ -211,8 +210,7 @@ struct DashboardView: View {
         if !documents.isEmpty {
             VStack(alignment: .leading, spacing: FacioLayout.space8) {
                 Label(title, systemImage: icon)
-                    .font(.subheadline)
-                    .fontWeight(.semibold)
+                    .font(FacioFont.subsectionTitle)
                     .foregroundStyle(tone.color)
                 ForEach(documents.prefix(4)) { doc in
                     Button {
@@ -235,8 +233,7 @@ struct DashboardView: View {
         if !timesheets.isEmpty {
             VStack(alignment: .leading, spacing: FacioLayout.space8) {
                 Label(title, systemImage: icon)
-                    .font(.subheadline)
-                    .fontWeight(.semibold)
+                    .font(FacioFont.subsectionTitle)
                     .foregroundStyle(tone.color)
                 ForEach(timesheets.prefix(4)) { timesheet in
                     Button {
@@ -257,7 +254,7 @@ struct DashboardView: View {
     private func recentDocumentList(title: String, empty: String, documents: [Document]) -> some View {
         VStack(alignment: .leading, spacing: FacioLayout.space10) {
             Text(title)
-                .font(.headline)
+                .font(FacioFont.sectionTitle)
             if documents.isEmpty {
                 FacioEmptyState(title: empty, systemImage: "tray")
                     .frame(maxWidth: .infinity, minHeight: 120)
@@ -282,11 +279,11 @@ struct DashboardView: View {
                     .fontWeight(.medium)
                     .lineLimit(1)
                 Text(doc.clientNom)
-                    .font(.caption)
+                    .font(FacioFont.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
                 Text(documentRowDetail(doc))
-                    .font(.caption2)
+                    .font(FacioFont.captionSmall)
                     .foregroundStyle(.tertiary)
                     .lineLimit(1)
             }
@@ -295,8 +292,7 @@ struct DashboardView: View {
             Spacer(minLength: FacioLayout.space10)
 
             Text(doc.currency.formatAccounting(doc.totalTTC, lang: numberFormat))
-                .font(.body.monospacedDigit())
-                .fontWeight(.medium)
+                .font(FacioFont.amount)
                 .lineLimit(1)
                 .minimumScaleFactor(0.72)
                 .frame(minWidth: 92, maxWidth: 130, alignment: .trailing)
@@ -316,7 +312,7 @@ struct DashboardView: View {
                     .fontWeight(.medium)
                     .lineLimit(1)
                 Text(timesheet.clientDisplayName.isEmpty ? L10n.noClient(lang) : timesheet.clientDisplayName)
-                    .font(.caption)
+                    .font(FacioFont.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
             }
@@ -325,8 +321,7 @@ struct DashboardView: View {
             Spacer(minLength: FacioLayout.space10)
 
             Text("\(hours)h")
-                .font(.body.monospacedDigit())
-                .fontWeight(.medium)
+                .font(FacioFont.amount)
                 .lineLimit(1)
             Image(systemName: "chevron.right")
                 .font(.caption)
@@ -337,7 +332,7 @@ struct DashboardView: View {
 
     private func overflowRow(count: Int) -> some View {
         Text(L10n.moreItems(lang, count: count))
-            .font(.caption)
+            .font(FacioFont.caption)
             .foregroundStyle(.secondary)
             .padding(.horizontal, FacioLayout.space10)
             .padding(.vertical, FacioLayout.space4)

--- a/Facio/Views/Documents/AddSignatureSheet.swift
+++ b/Facio/Views/Documents/AddSignatureSheet.swift
@@ -63,7 +63,6 @@ struct AddSignatureSheet: View {
                 .font(FacioFont.mono)
 
             TextField(L10n.amount(lang), value: $montant, format: .number)
-                .facioField()
 
             DatePicker(L10n.date(lang), selection: $date, displayedComponents: .date)
         }

--- a/Facio/Views/Documents/AddSignatureSheet.swift
+++ b/Facio/Views/Documents/AddSignatureSheet.swift
@@ -43,7 +43,7 @@ struct AddSignatureSheet: View {
     private var toolbar: some View {
         HStack {
             Text(L10n.addPaymentProof(lang))
-                .font(.headline)
+                .font(FacioFont.sectionTitle)
             Spacer()
             Button(L10n.cancel(lang)) { dismiss() }
                 .keyboardShortcut(.cancelAction)
@@ -63,6 +63,7 @@ struct AddSignatureSheet: View {
                 .font(FacioFont.mono)
 
             TextField(L10n.amount(lang), value: $montant, format: .number)
+                .facioField()
 
             DatePicker(L10n.date(lang), selection: $date, displayedComponents: .date)
         }

--- a/Facio/Views/Documents/ClientPickerSheet.swift
+++ b/Facio/Views/Documents/ClientPickerSheet.swift
@@ -48,7 +48,7 @@ struct ClientPickerSheet: View {
     private var toolbar: some View {
         HStack {
             Text(L10n.selectClient(lang))
-                .font(.headline)
+                .font(FacioFont.sectionTitle)
             Spacer()
             Button {
                 showNewClient.toggle()
@@ -67,24 +67,24 @@ struct ClientPickerSheet: View {
             SectionPanel(L10n.newClient(lang), systemImage: "person.crop.circle.badge.plus") {
                 VStack(spacing: FacioLayout.space8) {
                     TextField(L10n.name(lang), text: $newNom)
-                        .textFieldStyle(.roundedBorder)
+                        .facioField()
                     TextField(L10n.address(lang), text: $newAdresse)
-                        .textFieldStyle(.roundedBorder)
+                        .facioField()
                     HStack {
                         TextField(L10n.postalCode(lang), text: $newCodePostal)
-                            .textFieldStyle(.roundedBorder)
+                            .facioField()
                             .frame(maxWidth: 120)
                         TextField(L10n.city(lang), text: $newVille)
-                            .textFieldStyle(.roundedBorder)
+                            .facioField()
                     }
                     TextField(L10n.email(lang), text: $newEmail)
-                        .textFieldStyle(.roundedBorder)
+                        .facioField()
                     TextField(L10n.siret(lang), text: $newSiret)
-                        .textFieldStyle(.roundedBorder)
+                        .facioField()
                     TextField(L10n.vatNumber(lang), text: $newTva)
-                        .textFieldStyle(.roundedBorder)
+                        .facioField()
                     TextField(L10n.apeCode(lang), text: $newApe)
-                        .textFieldStyle(.roundedBorder)
+                        .facioField()
                     HStack {
                         Spacer()
                         Button(L10n.createAndSelect(lang)) {
@@ -117,10 +117,10 @@ struct ClientPickerSheet: View {
             } label: {
                 VStack(alignment: .leading, spacing: FacioLayout.space2) {
                     Text(client.nom)
-                        .font(.body)
+                        .font(FacioFont.body)
                     if !client.ville.isEmpty {
                         Text("\(client.adresse.isEmpty ? "" : "\(client.adresse), ")\(client.codePostal) \(client.ville)")
-                            .font(.caption)
+                            .font(FacioFont.caption)
                             .foregroundStyle(.secondary)
                     }
                     let identifiers = [
@@ -130,7 +130,7 @@ struct ClientPickerSheet: View {
                     ].compactMap { $0 }
                     if !identifiers.isEmpty {
                         Text(identifiers.joined(separator: " - "))
-                            .font(.caption2)
+                            .font(FacioFont.captionSmall)
                             .foregroundStyle(.tertiary)
                             .lineLimit(1)
                     }

--- a/Facio/Views/Documents/DocumentAttachmentsSection.swift
+++ b/Facio/Views/Documents/DocumentAttachmentsSection.swift
@@ -18,7 +18,7 @@ struct DocumentAttachmentsSection: View {
             VStack(alignment: .leading, spacing: FacioLayout.space12) {
                 if document.attachments.isEmpty {
                     Text(L10n.noAttachmentsHint(lang))
-                        .font(.caption)
+                        .font(FacioFont.caption)
                         .foregroundStyle(.tertiary)
                         .fixedSize(horizontal: false, vertical: true)
                 } else {
@@ -66,7 +66,7 @@ struct DocumentAttachmentsSection: View {
                     .font(.title3)
                     .foregroundStyle(.secondary)
                 Text(L10n.dropAttachmentHere(lang))
-                    .font(.caption)
+                    .font(FacioFont.caption)
                     .foregroundStyle(.secondary)
             }
         }
@@ -153,7 +153,7 @@ private struct AttachmentRowView: View {
                     Text("•")
                     Text(attachment.formattedSize)
                 }
-                .font(.caption2)
+                .font(FacioFont.captionSmall)
                 .foregroundStyle(.secondary)
             }
 

--- a/Facio/Views/Documents/DocumentEditorView.swift
+++ b/Facio/Views/Documents/DocumentEditorView.swift
@@ -196,8 +196,7 @@ struct DocumentEditorView: View {
         VStack(alignment: .leading, spacing: FacioLayout.space8) {
             HStack(spacing: FacioLayout.space8) {
                 Text(document.type.label(for: lang))
-                    .font(.subheadline)
-                    .fontWeight(.semibold)
+                    .font(FacioFont.subsectionTitle)
                     .foregroundStyle(Color.appPrimary(from: company))
                 StatusBadge(status: document.status, isOverdue: document.isOverdue)
             }
@@ -211,7 +210,7 @@ struct DocumentEditorView: View {
             .lineLimit(1)
 
             Text(document.clientNom.isEmpty ? L10n.noClient(lang) : document.clientNom)
-                .font(.subheadline)
+                .font(FacioFont.screenSubtitle)
                 .foregroundStyle(document.clientNom.isEmpty ? .tertiary : .secondary)
                 .lineLimit(1)
         }
@@ -221,11 +220,10 @@ struct DocumentEditorView: View {
     private var heroTotal: some View {
         VStack(alignment: .trailing, spacing: FacioLayout.space4) {
             Text(L10n.totalTTC(lang))
-                .font(.caption)
+                .font(FacioFont.caption)
                 .foregroundStyle(.secondary)
             Text(document.currency.formatAccounting(document.totalTTC, lang: dataStore.companyInfo.formatNombre))
-                .font(.title.monospacedDigit())
-                .fontWeight(.bold)
+                .font(FacioFont.metricValue)
                 .lineLimit(1)
                 .minimumScaleFactor(0.65)
         }
@@ -239,14 +237,14 @@ struct DocumentEditorView: View {
             } label: {
                 Label(L10n.preview(lang), systemImage: "eye")
             }
-            .buttonStyle(.bordered)
+            .buttonStyle(.facio(.secondary))
 
             Button {
                 exporterPDF()
             } label: {
                 Label(L10n.exportPDF(lang), systemImage: "square.and.arrow.up")
             }
-            .buttonStyle(.borderedProminent)
+            .buttonStyle(.facio(.primary))
         }
     }
 
@@ -406,7 +404,7 @@ struct DocumentEditorView: View {
             HStack(spacing: FacioLayout.space16) {
                 VStack(alignment: .leading, spacing: FacioLayout.space4) {
                     Text(L10n.type(lang))
-                        .font(.subheadline)
+                        .font(FacioFont.fieldLabel)
                         .foregroundStyle(.secondary)
                     Text(document.type.label(for: lang))
                         .font(.headline)
@@ -415,19 +413,19 @@ struct DocumentEditorView: View {
 
                 VStack(alignment: .leading, spacing: FacioLayout.space4) {
                     Text(L10n.number(lang))
-                        .font(.subheadline)
+                        .font(FacioFont.fieldLabel)
                         .foregroundStyle(.secondary)
                     TextField(L10n.number(lang), text: Binding(
                         get: { document.number },
                         set: { document.number = $0; scheduleSave() }
                     ))
-                    .textFieldStyle(.roundedBorder)
+                    .facioField()
                     .frame(maxWidth: 250)
                 }
 
                 VStack(alignment: .leading, spacing: FacioLayout.space4) {
                     Text(L10n.language(lang))
-                        .font(.subheadline)
+                        .font(FacioFont.fieldLabel)
                         .foregroundStyle(.secondary)
                     Picker("", selection: Binding(
                         get: { document.langue },
@@ -448,7 +446,7 @@ struct DocumentEditorView: View {
 
                 VStack(alignment: .leading, spacing: FacioLayout.space4) {
                     Text(L10n.status(lang))
-                        .font(.subheadline)
+                        .font(FacioFont.fieldLabel)
                         .foregroundStyle(.secondary)
                     Picker(L10n.status(lang), selection: Binding(
                         get: { document.status },
@@ -485,7 +483,7 @@ struct DocumentEditorView: View {
     /// En-tête d'une sous-section à l'intérieur d'un `SectionPanel` aplati.
     private func subsectionHeader(_ title: String) -> some View {
         Text(title)
-            .font(.subheadline.weight(.semibold))
+            .font(FacioFont.subsectionTitle)
             .foregroundStyle(.secondary)
     }
 
@@ -560,7 +558,7 @@ struct DocumentEditorView: View {
                 HStack(spacing: FacioLayout.space24) {
                     VStack(alignment: .leading, spacing: FacioLayout.space4) {
                         Text(L10n.accountingCurrency(lang))
-                            .font(.subheadline)
+                            .font(FacioFont.fieldLabel)
                             .foregroundStyle(.secondary)
                         Text(referenceCurrency.label)
                             .font(.headline)
@@ -568,7 +566,7 @@ struct DocumentEditorView: View {
 
                     VStack(alignment: .leading, spacing: FacioLayout.space4) {
                         Text(L10n.exchangeRate(lang))
-                            .font(.subheadline)
+                            .font(FacioFont.fieldLabel)
                             .foregroundStyle(.secondary)
                         HStack(spacing: FacioLayout.space8) {
                             Text(L10n.exchangeRatePrefix(lang, source: document.currency.label))
@@ -604,7 +602,7 @@ struct DocumentEditorView: View {
                     if let total = document.accountingTotal(referenceCurrency: referenceCurrency) {
                         VStack(alignment: .leading, spacing: FacioLayout.space4) {
                             Text(L10n.accountingTotal(lang))
-                                .font(.subheadline)
+                                .font(FacioFont.fieldLabel)
                                 .foregroundStyle(.secondary)
                             Text(referenceCurrency.formatAccounting(total, lang: dataStore.companyInfo.formatNombre))
                                 .font(.headline.monospacedDigit())
@@ -616,7 +614,7 @@ struct DocumentEditorView: View {
 
                 if document.accountingTotal(referenceCurrency: referenceCurrency) == nil {
                     Text(L10n.exchangeRateRequiredForDashboard(lang))
-                        .font(.caption)
+                        .font(FacioFont.caption)
                         .foregroundStyle(Color.intentWarning)
                 }
             }
@@ -630,7 +628,7 @@ struct DocumentEditorView: View {
             VStack(alignment: .leading, spacing: FacioLayout.space12) {
                 HStack {
                     Text(L10n.clientInfo(lang))
-                        .font(.subheadline)
+                        .font(FacioFont.fieldLabel)
                         .foregroundStyle(.secondary)
                     Spacer()
                     Button {
@@ -649,83 +647,83 @@ struct DocumentEditorView: View {
         VStack(alignment: .leading, spacing: FacioLayout.space12) {
             VStack(alignment: .leading, spacing: FacioLayout.space4) {
                 Text(L10n.name(lang))
-                    .font(.subheadline)
+                    .font(FacioFont.fieldLabel)
                     .foregroundStyle(.secondary)
                 TextField(L10n.clientName(lang), text: Binding(
                     get: { document.clientNom },
                     set: { document.clientNom = $0; scheduleSave() }
                 ))
-                .textFieldStyle(.roundedBorder)
+                .facioField()
             }
 
             VStack(alignment: .leading, spacing: FacioLayout.space4) {
                 Text(L10n.address(lang))
-                    .font(.subheadline)
+                    .font(FacioFont.fieldLabel)
                     .foregroundStyle(.secondary)
                 TextField(L10n.address(lang), text: Binding(
                     get: { document.clientAdresse },
                     set: { document.clientAdresse = $0; scheduleSave() }
                 ))
-                .textFieldStyle(.roundedBorder)
+                .facioField()
             }
 
             HStack(spacing: FacioLayout.space16) {
                 VStack(alignment: .leading, spacing: FacioLayout.space4) {
                     Text(L10n.postalCode(lang))
-                        .font(.subheadline)
+                        .font(FacioFont.fieldLabel)
                         .foregroundStyle(.secondary)
                     TextField(L10n.postalCode(lang), text: Binding(
                         get: { document.clientCodePostal },
                         set: { document.clientCodePostal = $0; scheduleSave() }
                     ))
-                    .textFieldStyle(.roundedBorder)
+                    .facioField()
                     .frame(maxWidth: 120)
                 }
 
                 VStack(alignment: .leading, spacing: FacioLayout.space4) {
                     Text(L10n.city(lang))
-                        .font(.subheadline)
+                        .font(FacioFont.fieldLabel)
                         .foregroundStyle(.secondary)
                     TextField(L10n.city(lang), text: Binding(
                         get: { document.clientVille },
                         set: { document.clientVille = $0; scheduleSave() }
                     ))
-                    .textFieldStyle(.roundedBorder)
+                    .facioField()
                 }
             }
 
             HStack(spacing: FacioLayout.space16) {
                 VStack(alignment: .leading, spacing: FacioLayout.space4) {
                     Text(L10n.siret(lang))
-                        .font(.subheadline)
+                        .font(FacioFont.fieldLabel)
                         .foregroundStyle(.secondary)
                     TextField(L10n.siret(lang), text: Binding(
                         get: { document.clientSiret },
                         set: { document.clientSiret = $0; scheduleSave() }
                     ))
-                    .textFieldStyle(.roundedBorder)
+                    .facioField()
                 }
 
                 VStack(alignment: .leading, spacing: FacioLayout.space4) {
                     Text(L10n.vatNumber(lang))
-                        .font(.subheadline)
+                        .font(FacioFont.fieldLabel)
                         .foregroundStyle(.secondary)
                     TextField(L10n.vatNumber(lang), text: Binding(
                         get: { document.clientTva },
                         set: { document.clientTva = $0; scheduleSave() }
                     ))
-                    .textFieldStyle(.roundedBorder)
+                    .facioField()
                 }
 
                 VStack(alignment: .leading, spacing: FacioLayout.space4) {
                     Text(L10n.apeCode(lang))
-                        .font(.subheadline)
+                        .font(FacioFont.fieldLabel)
                         .foregroundStyle(.secondary)
                     TextField(L10n.apeCode(lang), text: Binding(
                         get: { document.clientApe },
                         set: { document.clientApe = $0; scheduleSave() }
                     ))
-                    .textFieldStyle(.roundedBorder)
+                    .facioField()
                 }
             }
         }
@@ -746,7 +744,7 @@ struct DocumentEditorView: View {
                 set: { document.notes = $0; scheduleSave() }
             ))
             .frame(minHeight: 60, maxHeight: 120)
-            .font(.body)
+            .font(FacioFont.body)
             .padding(FacioLayout.space4)
         }
     }

--- a/Facio/Views/Documents/DocumentEditorView.swift
+++ b/Facio/Views/Documents/DocumentEditorView.swift
@@ -205,7 +205,7 @@ struct DocumentEditorView: View {
                 get: { document.number },
                 set: { document.number = $0; scheduleSave() }
             ))
-            .font(.title2.weight(.semibold))
+            .font(FacioFont.heroTitle)
             .textFieldStyle(.plain)
             .lineLimit(1)
 
@@ -223,7 +223,7 @@ struct DocumentEditorView: View {
                 .font(FacioFont.caption)
                 .foregroundStyle(.secondary)
             Text(document.currency.formatAccounting(document.totalTTC, lang: dataStore.companyInfo.formatNombre))
-                .font(FacioFont.metricValue)
+                .font(FacioFont.heroTotal)
                 .lineLimit(1)
                 .minimumScaleFactor(0.65)
         }
@@ -593,6 +593,7 @@ struct DocumentEditorView: View {
                                 ),
                                 maximumFractionDigits: 8
                             )
+                            .density(.regular)
                             .frame(maxWidth: 140)
                             Text(referenceCurrency.label)
                                 .foregroundStyle(.secondary)

--- a/Facio/Views/Documents/DocumentListView.swift
+++ b/Facio/Views/Documents/DocumentListView.swift
@@ -195,7 +195,7 @@ struct DocumentRowView: View {
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                     Text(dateSummary)
-                        .font(.caption)
+                        .font(FacioFont.caption)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
                 }
@@ -205,8 +205,7 @@ struct DocumentRowView: View {
             Spacer(minLength: 8)
 
             Text(document.currency.formatAccounting(document.totalTTC, lang: numberFormat))
-                .font(.body.monospacedDigit())
-                .fontWeight(.medium)
+                .font(FacioFont.amount)
                 .lineLimit(1)
                 .minimumScaleFactor(0.75)
                 .frame(minWidth: 86, maxWidth: 120, alignment: .trailing)

--- a/Facio/Views/Documents/DocumentSignaturesSection.swift
+++ b/Facio/Views/Documents/DocumentSignaturesSection.swift
@@ -62,16 +62,16 @@ private struct SignatureRowView: View {
                     .truncationMode(.middle)
                 HStack(spacing: FacioLayout.space8) {
                     Text(signature.blockchain.label)
-                        .font(.caption2)
+                        .font(FacioFont.captionSmall)
                         .padding(.horizontal, FacioLayout.space6)
                         .padding(.vertical, FacioLayout.space2)
                         .background(Color.appPrimary.opacity(0.1))
                         .clipShape(Capsule())
                     Text(signature.date.formattedDate(for: dateFormat))
-                        .font(.caption2)
+                        .font(FacioFont.captionSmall)
                         .foregroundStyle(.secondary)
                     Text(document.currency.formatAccounting(signature.montant, lang: numberFormat))
-                        .font(.caption2)
+                        .font(FacioFont.captionSmall)
                         .foregroundStyle(.secondary)
                 }
             }
@@ -79,7 +79,7 @@ private struct SignatureRowView: View {
             if let url = signature.explorerURL {
                 Link(destination: url) {
                     Label(L10n.viewOn(lang, explorer: signature.explorerName), systemImage: "arrow.up.right.square")
-                        .font(.caption)
+                        .font(FacioFont.caption)
                 }
             }
             FacioIconButton(

--- a/Facio/Views/Documents/LineItemRowView.swift
+++ b/Facio/Views/Documents/LineItemRowView.swift
@@ -35,7 +35,7 @@ struct LineItemRowView: View {
                         if let i = safeIndex() { document.lignes[i].designation = newVal; onUpdate() }
                     }
                 ))
-                .textFieldStyle(.roundedBorder)
+                .facioField(density: .compact)
                 .frame(maxWidth: .infinity)
 
                 // Quantite
@@ -81,7 +81,7 @@ struct LineItemRowView: View {
 
                 // Total (lecture seule)
                 Text(document.currency.formatAccounting(currentLigne.totalLigne, lang: numberFormat))
-                    .font(.body.monospacedDigit())
+                    .font(FacioFont.amount)
                     .frame(width: LineItemColumns.totalHT, alignment: .trailing)
 
                 Menu {

--- a/Facio/Views/Documents/LineItemRowView.swift
+++ b/Facio/Views/Documents/LineItemRowView.swift
@@ -137,9 +137,9 @@ struct DecimalField: View {
 
     var body: some View {
         TextField(placeholder, text: $text)
-            .textFieldStyle(.roundedBorder)
             .multilineTextAlignment(.trailing)
             .focused($isFocused)
+            .facioField(density: .compact)
             .onAppear {
                 text = value == 0 ? "" : formatDecimal(value)
             }

--- a/Facio/Views/Documents/LineItemRowView.swift
+++ b/Facio/Views/Documents/LineItemRowView.swift
@@ -73,7 +73,7 @@ struct LineItemRowView: View {
                     }
                 )) {
                     ForEach(Self.tvaRates, id: \.self) { rate in
-                        Text("\(NSDecimalNumber(decimal: rate))%").tag(rate)
+                        Text(L10n.vatRateLabel(numberFormat, rate: rate)).tag(rate)
                     }
                 }
                 .labelsHidden()

--- a/Facio/Views/Documents/LineItemRowView.swift
+++ b/Facio/Views/Documents/LineItemRowView.swift
@@ -132,6 +132,9 @@ struct DecimalField: View {
     @Binding var value: Decimal
     var maximumFractionDigits: Int = 2
     var format: AppLanguage = .fr
+    /// `.compact` par défaut (lignes de tableau) ; passer en `.regular` via
+    /// `.density(.regular)` dans les formulaires.
+    var density: FacioFieldDensity = .compact
     @State private var text: String = ""
     @FocusState private var isFocused: Bool
 
@@ -139,7 +142,7 @@ struct DecimalField: View {
         TextField(placeholder, text: $text)
             .multilineTextAlignment(.trailing)
             .focused($isFocused)
-            .facioField(density: .compact)
+            .facioField(density: density)
             .onAppear {
                 text = value == 0 ? "" : formatDecimal(value)
             }
@@ -166,6 +169,12 @@ struct DecimalField: View {
     func format(_ format: AppLanguage) -> Self {
         var copy = self
         copy.format = format
+        return copy
+    }
+
+    func density(_ density: FacioFieldDensity) -> Self {
+        var copy = self
+        copy.density = density
         return copy
     }
 

--- a/Facio/Views/Documents/TotalsView.swift
+++ b/Facio/Views/Documents/TotalsView.swift
@@ -45,11 +45,10 @@ struct TotalsView: View {
 
                     HStack {
                         Text(L10n.totalTTC(lang))
-                            .font(.headline)
+                            .font(FacioFont.sectionTitle)
                         Spacer()
                         Text(document.currency.formatAccounting(document.totalTTC, lang: numberFormat))
-                            .font(.title3.monospacedDigit())
-                            .fontWeight(.bold)
+                            .font(FacioFont.amountEmphasis)
                     }
                 }
             }
@@ -60,11 +59,11 @@ struct TotalsView: View {
     private func totalRow(label: String, value: String, isDetail: Bool) -> some View {
         HStack {
             Text(label)
-                .font(isDetail ? Font.caption : Font.body)
+                .font(isDetail ? FacioFont.caption : FacioFont.body)
                 .foregroundStyle(isDetail ? .secondary : .primary)
             Spacer()
             Text(value)
-                .font(isDetail ? Font.caption.monospacedDigit() : Font.body.monospacedDigit())
+                .font(isDetail ? FacioFont.metaValue : FacioFont.amount)
                 .foregroundStyle(isDetail ? .secondary : .primary)
         }
     }

--- a/Facio/Views/Settings/AboutSettingsView.swift
+++ b/Facio/Views/Settings/AboutSettingsView.swift
@@ -30,6 +30,7 @@ struct AboutSettingsView: View {
                                 .frame(width: 64, height: 64)
                                 .overlay {
                                     Text("F")
+                                        // Taille décorative unique (logo de repli) : hors échelle FacioFont, volontairement.
                                         .font(.system(size: 32, weight: .bold, design: .rounded))
                                         .foregroundStyle(.white)
                                 }
@@ -38,15 +39,14 @@ struct AboutSettingsView: View {
 
                     VStack(alignment: .leading, spacing: FacioLayout.space4) {
                         Text("Facio")
-                            .font(.title)
-                            .fontWeight(.bold)
+                            .font(FacioFont.screenTitle)
 
                         Text(L10n.version(lang, value: appVersion))
-                            .font(.subheadline)
+                            .font(FacioFont.screenSubtitle)
                             .foregroundStyle(.secondary)
 
                         Text(L10n.professionalInvoices(lang))
-                            .font(.caption)
+                            .font(FacioFont.caption)
                             .foregroundStyle(.tertiary)
                     }
 
@@ -90,9 +90,8 @@ struct AboutSettingsView: View {
                             .font(.subheadline)
                             .padding(.horizontal, FacioLayout.space12)
                             .padding(.vertical, FacioLayout.space8)
-                            .background(.quaternary)
                             .contentShape(RoundedRectangle(cornerRadius: FacioLayout.radiusPanel))
-                            .clipShape(RoundedRectangle(cornerRadius: FacioLayout.radiusPanel))
+                            .facioCardChrome(surface: .surfaceTile)
                         }
                         .buttonStyle(.plain)
                         .disabled(updateService.isChecking)
@@ -129,10 +128,10 @@ struct AboutSettingsView: View {
                             .font(.subheadline)
                             .padding(.horizontal, FacioLayout.space12)
                             .padding(.vertical, FacioLayout.space8)
-                            .background(Color.intentDanger.opacity(0.1))
                             .foregroundStyle(Color.intentDanger)
                             .contentShape(RoundedRectangle(cornerRadius: FacioLayout.radiusPanel))
-                            .clipShape(RoundedRectangle(cornerRadius: FacioLayout.radiusPanel))
+                            // Surface teintée danger conservée (affordance destructive), chrome standardisé.
+                            .facioCardChrome(surface: Color.intentDanger.opacity(0.1))
                         }
                         .buttonStyle(.plain)
                         .help(L10n.resetHelp(lang))
@@ -147,10 +146,10 @@ struct AboutSettingsView: View {
                             .font(.subheadline)
                             .padding(.horizontal, FacioLayout.space12)
                             .padding(.vertical, FacioLayout.space8)
-                            .background(Color.intentDanger.opacity(0.1))
                             .foregroundStyle(Color.intentDanger)
                             .contentShape(RoundedRectangle(cornerRadius: FacioLayout.radiusPanel))
-                            .clipShape(RoundedRectangle(cornerRadius: FacioLayout.radiusPanel))
+                            // Surface teintée danger conservée (affordance destructive), chrome standardisé.
+                            .facioCardChrome(surface: Color.intentDanger.opacity(0.1))
                         }
                         .buttonStyle(.plain)
                         .help(L10n.uninstallHelp(lang))
@@ -161,13 +160,13 @@ struct AboutSettingsView: View {
                             Image(systemName: "checkmark.circle.fill")
                                 .foregroundStyle(Color.intentSuccess)
                             Text(L10n.resetDone(lang))
-                                .font(.caption)
+                                .font(FacioFont.caption)
                                 .foregroundStyle(Color.intentSuccess)
                         }
                     }
 
                     Text(L10n.irreversibleWarning(lang))
-                        .font(.caption)
+                        .font(FacioFont.caption)
                         .foregroundStyle(.tertiary)
                 }
             }
@@ -201,9 +200,8 @@ struct AboutSettingsView: View {
             }
             .padding(.horizontal, FacioLayout.space12)
             .padding(.vertical, FacioLayout.space8)
-            .background(.quaternary)
             .contentShape(RoundedRectangle(cornerRadius: FacioLayout.radiusPanel))
-            .clipShape(RoundedRectangle(cornerRadius: FacioLayout.radiusPanel))
+            .facioCardChrome(surface: .surfaceTile)
         }
         .buttonStyle(.plain)
     }

--- a/Facio/Views/Settings/AboutSettingsView.swift
+++ b/Facio/Views/Settings/AboutSettingsView.swift
@@ -254,7 +254,6 @@ struct AboutSettingsView: View {
             Image(systemName: icon)
                 .foregroundStyle(color)
             Text(text)
-                .font(.subheadline)
                 .foregroundStyle(color)
         }
         .font(.subheadline)

--- a/Facio/Views/Settings/CompanySettingsView.swift
+++ b/Facio/Views/Settings/CompanySettingsView.swift
@@ -19,7 +19,7 @@ struct CompanySettingsView: View {
                             get: { company.nom },
                             set: { company.nom = $0; dataStore.companyUpdated() }
                         ))
-                        .textFieldStyle(.roundedBorder)
+                        .facioField()
                     }
 
                     LabeledField(L10n.address(lang)) {
@@ -27,7 +27,7 @@ struct CompanySettingsView: View {
                             get: { company.adresse },
                             set: { company.adresse = $0; dataStore.companyUpdated() }
                         ))
-                        .textFieldStyle(.roundedBorder)
+                        .facioField()
                     }
 
                     HStack(alignment: .top, spacing: FacioLayout.space12) {
@@ -36,7 +36,7 @@ struct CompanySettingsView: View {
                                 get: { company.codePostal },
                                 set: { company.codePostal = $0; dataStore.companyUpdated() }
                             ))
-                            .textFieldStyle(.roundedBorder)
+                            .facioField()
                             .frame(maxWidth: 120)
                         }
 
@@ -45,7 +45,7 @@ struct CompanySettingsView: View {
                                 get: { company.ville },
                                 set: { company.ville = $0; dataStore.companyUpdated() }
                             ))
-                            .textFieldStyle(.roundedBorder)
+                            .facioField()
                         }
                     }
 
@@ -54,7 +54,7 @@ struct CompanySettingsView: View {
                             get: { company.siret },
                             set: { company.siret = $0; dataStore.companyUpdated() }
                         ))
-                        .textFieldStyle(.roundedBorder)
+                        .facioField()
                     }
                 }
             }
@@ -67,7 +67,7 @@ struct CompanySettingsView: View {
                             get: { company.telephone },
                             set: { company.telephone = $0; dataStore.companyUpdated() }
                         ))
-                        .textFieldStyle(.roundedBorder)
+                        .facioField()
                     }
 
                     LabeledField(L10n.email(lang)) {
@@ -75,7 +75,7 @@ struct CompanySettingsView: View {
                             get: { company.email },
                             set: { company.email = $0; dataStore.companyUpdated() }
                         ))
-                        .textFieldStyle(.roundedBorder)
+                        .facioField()
                     }
                 }
             }

--- a/Facio/Views/Settings/CustomisationSettingsView.swift
+++ b/Facio/Views/Settings/CustomisationSettingsView.swift
@@ -70,7 +70,7 @@ struct CustomisationSettingsView: View {
                                     .font(.title2)
                                     .foregroundStyle(.secondary)
                                 Text(L10n.dragImageHere(lang))
-                                    .font(.caption)
+                                    .font(FacioFont.caption)
                                     .foregroundStyle(.secondary)
                             }
                         }
@@ -109,7 +109,7 @@ struct CustomisationSettingsView: View {
                     // Apercu
                     VStack(alignment: .leading, spacing: FacioLayout.space6) {
                         Text(L10n.colorPreview(lang))
-                            .font(.subheadline)
+                            .font(FacioFont.fieldLabel)
                             .foregroundStyle(.secondary)
 
                         HStack(spacing: FacioLayout.space12) {
@@ -138,7 +138,7 @@ struct CustomisationSettingsView: View {
                         .strokeBorder(Color.primary.opacity(0.15), lineWidth: 0.5)
                 )
             Text(label)
-                .font(.caption2)
+                .font(FacioFont.captionSmall)
                 .foregroundStyle(.secondary)
         }
     }

--- a/Facio/Views/Settings/DefaultsSettingsView.swift
+++ b/Facio/Views/Settings/DefaultsSettingsView.swift
@@ -89,7 +89,7 @@ struct DefaultsSettingsView: View {
                 VStack(alignment: .leading, spacing: FacioLayout.space16) {
                     HStack {
                         Text(L10n.defaultDelay(lang))
-                            .font(.subheadline)
+                            .font(FacioFont.fieldLabel)
                             .foregroundStyle(.secondary)
                         Spacer()
                         Stepper(

--- a/Facio/Views/Settings/EmailSettingsView.swift
+++ b/Facio/Views/Settings/EmailSettingsView.swift
@@ -27,12 +27,12 @@ struct EmailSettingsView: View {
 
                     LabeledField(L10n.emailSubjectLabel(lang)) {
                         TextField("", text: subjectBinding)
-                            .textFieldStyle(.roundedBorder)
+                            .facioField()
                     }
 
                     LabeledField(L10n.emailBodyLabel(lang)) {
                         TextEditor(text: bodyBinding)
-                            .font(.body)
+                            .font(FacioFont.body)
                             .frame(minHeight: 160)
                             .padding(FacioLayout.space4)
                             .overlay(
@@ -42,7 +42,7 @@ struct EmailSettingsView: View {
                     }
 
                     Text(L10n.emailPlaceholdersHelp(lang))
-                        .font(.caption)
+                        .font(FacioFont.caption)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
 

--- a/Facio/Views/Settings/LanguageSettingsView.swift
+++ b/Facio/Views/Settings/LanguageSettingsView.swift
@@ -28,7 +28,7 @@ struct LanguageSettingsView: View {
                     }
 
                     Text(L10n.defaultLanguageHint(lang))
-                        .font(.caption)
+                        .font(FacioFont.caption)
                         .foregroundStyle(.secondary)
                 }
             }

--- a/Facio/Views/Settings/PaymentSettingsView.swift
+++ b/Facio/Views/Settings/PaymentSettingsView.swift
@@ -107,14 +107,14 @@ private struct BankAccountRow: View {
                         get: { account?.label ?? "" },
                         set: { setAccountValue(\.label, to: $0) }
                     ))
-                    .textFieldStyle(.roundedBorder)
+                    .facioField()
                     .frame(maxWidth: 220)
 
                     TextField(L10n.bankNamePlaceholder(lang), text: Binding(
                         get: { account?.bankName ?? "" },
                         set: { setAccountValue(\.bankName, to: $0) }
                     ))
-                    .textFieldStyle(.roundedBorder)
+                    .facioField()
 
                     Button {
                         company.bankAccounts.removeAll { $0.id == accountId }
@@ -136,8 +136,8 @@ private struct BankAccountRow: View {
                         get: { account?.iban ?? "" },
                         set: { setAccountValue(\.iban, to: $0) }
                     ))
-                    .font(.system(.body, design: .monospaced))
-                    .textFieldStyle(.roundedBorder)
+                    .font(FacioFont.mono)
+                    .facioField()
                 }
 
                 HStack(spacing: FacioLayout.space12) {
@@ -146,8 +146,8 @@ private struct BankAccountRow: View {
                             get: { account?.bic ?? "" },
                             set: { setAccountValue(\.bic, to: $0) }
                         ))
-                        .font(.system(.body, design: .monospaced))
-                        .textFieldStyle(.roundedBorder)
+                        .font(FacioFont.mono)
+                        .facioField()
                     }
 
                     LabeledField(L10n.accountHolderLabel(lang)) {
@@ -155,7 +155,7 @@ private struct BankAccountRow: View {
                             get: { account?.accountHolder ?? "" },
                             set: { setAccountValue(\.accountHolder, to: $0) }
                         ))
-                        .textFieldStyle(.roundedBorder)
+                        .facioField()
                     }
                 }
 
@@ -164,7 +164,7 @@ private struct BankAccountRow: View {
                         Image(systemName: "exclamationmark.triangle")
                         Text(L10n.bankAccountIbanRequired(lang))
                     }
-                    .font(.caption)
+                    .font(FacioFont.caption)
                     .foregroundStyle(Color.intentWarning)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
@@ -225,7 +225,7 @@ private struct WalletRow: View {
                             if let i = safeIndex() { company.wallets[i].label = newVal; dataStore.companyUpdated() }
                         }
                     ))
-                    .textFieldStyle(.roundedBorder)
+                    .facioField()
                     .frame(maxWidth: 200)
 
                     Button {
@@ -248,14 +248,14 @@ private struct WalletRow: View {
                         if let i = safeIndex() { company.wallets[i].address = newVal; dataStore.companyUpdated() }
                     }
                 ))
-                .textFieldStyle(.roundedBorder)
+                .facioField()
 
                 if walletAddress.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                     HStack(spacing: FacioLayout.space6) {
                         Image(systemName: "exclamationmark.triangle")
                         Text(L10n.walletAddressRequired(lang))
                     }
-                    .font(.caption)
+                    .font(FacioFont.caption)
                     .foregroundStyle(Color.intentWarning)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }

--- a/Facio/Views/Settings/PrestationsSettingsView.swift
+++ b/Facio/Views/Settings/PrestationsSettingsView.swift
@@ -44,7 +44,7 @@ struct PrestationsSettingsView: View {
                                 .frame(width: 75, alignment: .center)
                             Spacer().frame(width: 28)
                         }
-                        .font(.caption)
+                        .font(FacioFont.caption)
                         .foregroundStyle(.secondary)
                         .padding(.horizontal, FacioLayout.space4)
 
@@ -94,7 +94,7 @@ private struct PrestationRow: View {
                         if let i = safeIndex() { company.prestations[i].designation = newVal; dataStore.companyUpdated() }
                     }
                 ))
-                .textFieldStyle(.roundedBorder)
+                .facioField(density: .compact)
                 .frame(maxWidth: .infinity)
 
                 DecimalField(

--- a/Facio/Views/Settings/SettingsInlineView.swift
+++ b/Facio/Views/Settings/SettingsInlineView.swift
@@ -67,10 +67,9 @@ struct SettingsInlineView: View {
     private var settingsHeader: some View {
         VStack(alignment: .leading, spacing: 6) {
             Label(selectedTabInfo.label, systemImage: selectedTabInfo.icon)
-                .font(.largeTitle)
-                .fontWeight(.bold)
+                .font(FacioFont.screenTitle)
             Text(selectedTabInfo.help)
-                .font(.subheadline)
+                .font(FacioFont.screenSubtitle)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
         }

--- a/Facio/Views/Settings/SyncSettingsView.swift
+++ b/Facio/Views/Settings/SyncSettingsView.swift
@@ -30,7 +30,7 @@ struct SyncSettingsView: View {
 
                     if isEnabled {
                         Text(L10n.syncDescription(lang))
-                            .font(.caption)
+                            .font(FacioFont.caption)
                             .foregroundStyle(.secondary)
                     }
                 }
@@ -64,7 +64,7 @@ struct SyncSettingsView: View {
 
                             LabeledField(L10n.verificationCode(lang)) {
                                 TextField(L10n.otpCodePlaceholder(lang), text: $otpCode)
-                                    .textFieldStyle(.roundedBorder)
+                                    .facioField()
                                     .frame(maxWidth: 200)
                             }
 
@@ -78,6 +78,7 @@ struct SyncSettingsView: View {
                                         }
                                     }
                                 }
+                                .buttonStyle(.facio(.primary))
                                 .disabled(otpCode.count < 6 || authService.isLoading)
 
                                 Button(L10n.resendCode(lang)) {
@@ -104,17 +105,18 @@ struct SyncSettingsView: View {
                         } else {
                             // Step 1: Enter email
                             Text(L10n.emailLoginPrompt(lang))
-                                .font(.caption)
+                                .font(FacioFont.caption)
                                 .foregroundStyle(.secondary)
 
                             LabeledField(L10n.email(lang)) {
                                 TextField(L10n.emailPlaceholder(lang), text: $email)
-                                    .textFieldStyle(.roundedBorder)
+                                    .facioField()
                             }
 
                             Button(L10n.receiveCode(lang)) {
                                 Task { await authService.sendOTP(email: email) }
                             }
+                            .buttonStyle(.facio(.primary))
                             .disabled(email.isEmpty || !email.contains("@") || authService.isLoading)
 
                             if authService.isLoading {
@@ -163,6 +165,7 @@ struct SyncSettingsView: View {
                             Button(L10n.synchronize(lang)) {
                                 Task { await syncService.fullSync(dataStore: dataStore) }
                             }
+                            .buttonStyle(.facio(.primary))
                             .disabled(syncService.isSyncing)
 
                             Button(L10n.pushAll(lang)) {
@@ -174,6 +177,7 @@ struct SyncSettingsView: View {
                                     await syncService.pushAllDirty()
                                 }
                             }
+                            .buttonStyle(.facio(.secondary))
                             .disabled(syncService.isSyncing)
                         }
                     }
@@ -195,7 +199,7 @@ struct SyncSettingsView: View {
                         if useCustomDB {
                             LabeledField(L10n.supabaseURL(lang)) {
                                 TextField(L10n.supabaseURLPlaceholder(lang), text: $customURL)
-                                    .textFieldStyle(.roundedBorder)
+                                    .facioField()
                                     .onChange(of: customURL) { SyncConfig.customURL = customURL }
                             }
 
@@ -203,10 +207,10 @@ struct SyncSettingsView: View {
                                 HStack {
                                     if showApiKey {
                                         TextField(L10n.apiKeyPlaceholder(lang), text: $customAPIKey)
-                                            .textFieldStyle(.roundedBorder)
+                                            .facioField()
                                     } else {
                                         SecureField(L10n.apiKey(lang), text: $customAPIKey)
-                                            .textFieldStyle(.roundedBorder)
+                                            .facioField()
                                     }
                                     Button {
                                         showApiKey.toggle()
@@ -227,7 +231,7 @@ struct SyncSettingsView: View {
                             // SQL helper
                             DisclosureGroup(L10n.sqlSchema(lang), isExpanded: $showSQL) {
                                 Text(SyncService.sqlSchema)
-                                    .font(.system(.caption2, design: .monospaced))
+                                    .font(FacioFont.monoCaption)
                                     .textSelection(.enabled)
                                     .padding(FacioLayout.space8)
                                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -240,7 +244,7 @@ struct SyncSettingsView: View {
                                 }
                                 .buttonStyle(.borderless)
                             }
-                            .font(.caption)
+                            .font(FacioFont.caption)
                             .foregroundStyle(.secondary)
                         }
                     }

--- a/Facio/Views/Sidebar/SidebarView.swift
+++ b/Facio/Views/Sidebar/SidebarView.swift
@@ -62,14 +62,14 @@ struct SidebarView: View {
                         Image(systemName: "building.2")
                             .foregroundStyle(Color.appPrimary(from: dataStore.companyInfo))
                         Text(companyName)
-                            .font(.headline)
+                            .font(FacioFont.sectionTitle)
                             .lineLimit(1)
                             .help(companyName)
                     }
 
                     if let running = dataStore.runningTimeEntryContext {
                         Label(running.timesheet.clientDisplayName.isEmpty ? L10n.timerRunning(lang) : running.timesheet.clientDisplayName, systemImage: "timer")
-                            .font(.caption)
+                            .font(FacioFont.caption)
                             .foregroundStyle(Color.intentSuccess)
                             .lineLimit(1)
                     }

--- a/Facio/Views/TimeHub/SharedTimerBarView.swift
+++ b/Facio/Views/TimeHub/SharedTimerBarView.swift
@@ -103,18 +103,18 @@ struct SharedTimerBarView: View {
         if let activeContext {
             TextField(L10n.timeEntryDescription(lang), text: entryStringBinding(activeContext, \.notes))
                 .font(.title3)
-                .textFieldStyle(.roundedBorder)
+                .facioField(density: .compact)
         } else {
             TextField(L10n.timeEntryDescription(lang), text: $notes)
                 .font(.title3)
-                .textFieldStyle(.roundedBorder)
+                .facioField(density: .compact)
         }
     }
 
     private func timerControls(now: Date) -> some View {
         HStack(spacing: FacioLayout.space12) {
             Label(L10n.timeTracker(lang), systemImage: "timer")
-                .font(.headline)
+                .font(FacioFont.sectionTitle)
                 .foregroundStyle(.secondary)
 
             Spacer(minLength: FacioLayout.space8)
@@ -131,8 +131,7 @@ struct SharedTimerBarView: View {
                 } label: {
                     Label(L10n.stopTimer(lang), systemImage: "stop.fill")
                 }
-                .buttonStyle(.borderedProminent)
-                .tint(Color.intentDanger)
+                .buttonStyle(.facio(.destructive))
                 .help(L10n.stopTimer(lang))
             } else {
                 Button {
@@ -140,7 +139,7 @@ struct SharedTimerBarView: View {
                 } label: {
                     Label(L10n.startTimer(lang), systemImage: "play.fill")
                 }
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(.facio(.primary))
                 .disabled(selectedTimesheet == nil || liveStartDateRange == nil)
                 .help(L10n.startTimer(lang))
             }
@@ -161,11 +160,11 @@ struct SharedTimerBarView: View {
             periodPicker
                 .frame(minWidth: 220)
             TextField(L10n.project(lang), text: $projectName)
-                .textFieldStyle(.roundedBorder)
+                .facioField(density: .compact)
             TextField(L10n.task(lang), text: $taskName)
-                .textFieldStyle(.roundedBorder)
+                .facioField(density: .compact)
             TextField(L10n.tags(lang), text: $tagsText)
-                .textFieldStyle(.roundedBorder)
+                .facioField(density: .compact)
             Toggle(L10n.billable(lang), isOn: $isBillable)
                 .toggleStyle(.switch)
             startedEarlierControl
@@ -177,11 +176,11 @@ struct SharedTimerBarView: View {
             periodPicker
             HStack(spacing: FacioLayout.space10) {
                 TextField(L10n.project(lang), text: $projectName)
-                    .textFieldStyle(.roundedBorder)
+                    .facioField(density: .compact)
                 TextField(L10n.task(lang), text: $taskName)
-                    .textFieldStyle(.roundedBorder)
+                    .facioField(density: .compact)
                 TextField(L10n.tags(lang), text: $tagsText)
-                    .textFieldStyle(.roundedBorder)
+                    .facioField(density: .compact)
             }
             HStack(spacing: FacioLayout.space10) {
                 Toggle(L10n.billable(lang), isOn: $isBillable)
@@ -240,7 +239,7 @@ struct SharedTimerBarView: View {
 
     private func activePeriodLabel(_ context: RunningTimeEntryContext) -> some View {
         Label(context.timesheet.title(for: lang), systemImage: "calendar.badge.clock")
-            .font(.caption)
+            .font(FacioFont.caption)
             .foregroundStyle(.secondary)
             .lineLimit(1)
             .frame(minWidth: 180, alignment: .leading)
@@ -249,11 +248,11 @@ struct SharedTimerBarView: View {
     private func activeMetadataFields(_ context: RunningTimeEntryContext) -> some View {
         HStack(spacing: FacioLayout.space10) {
             TextField(L10n.project(lang), text: entryStringBinding(context, \.projectName))
-                .textFieldStyle(.roundedBorder)
+                .facioField(density: .compact)
             TextField(L10n.task(lang), text: entryStringBinding(context, \.taskName))
-                .textFieldStyle(.roundedBorder)
+                .facioField(density: .compact)
             TextField(L10n.tags(lang), text: entryStringBinding(context, \.tagsText))
-                .textFieldStyle(.roundedBorder)
+                .facioField(density: .compact)
             Toggle(L10n.billable(lang), isOn: entryBoolBinding(context, \.isBillable))
                 .toggleStyle(.switch)
         }
@@ -262,7 +261,7 @@ struct SharedTimerBarView: View {
     private func activeStartDatePicker(_ context: RunningTimeEntryContext) -> some View {
         HStack(spacing: FacioLayout.space10) {
             Label(L10n.startDate(lang), systemImage: "clock.arrow.circlepath")
-                .font(.caption)
+                .font(FacioFont.caption)
                 .foregroundStyle(.secondary)
             DatePicker(
                 L10n.startDate(lang),

--- a/Facio/Views/TimeHub/TimeHubView.swift
+++ b/Facio/Views/TimeHub/TimeHubView.swift
@@ -93,10 +93,9 @@ struct TimeHubView: View {
                 HStack(alignment: .center, spacing: FacioLayout.space12) {
                     VStack(alignment: .leading, spacing: FacioLayout.space2) {
                         Label(L10n.sidebarPlanning(lang), systemImage: "calendar.badge.clock")
-                            .font(.largeTitle)
-                            .fontWeight(.bold)
+                            .font(FacioFont.screenTitle)
                         Text(periodTitle(interval))
-                            .font(.subheadline)
+                            .font(FacioFont.screenSubtitle)
                             .foregroundStyle(.secondary)
                     }
 
@@ -155,7 +154,7 @@ struct TimeHubView: View {
                     .frame(width: 170)
 
                     TextField(L10n.searchTimeHub(lang), text: $filters.searchText)
-                        .textFieldStyle(.roundedBorder)
+                        .facioField()
 
                     Button {
                         showManualEntrySheet = true
@@ -267,8 +266,7 @@ struct TimeHubView: View {
             VStack(alignment: .leading, spacing: FacioLayout.space10) {
                 HStack {
                     Text(formatDuration(stats.totalSeconds))
-                        .font(.title2.monospacedDigit())
-                        .fontWeight(.semibold)
+                        .font(FacioFont.metricValue)
                     Spacer()
                     Button(L10n.openLogToday(lang)) {
                         periodMode = .day
@@ -373,7 +371,7 @@ struct TimeHubView: View {
                             } label: {
                                 Label(L10n.createInvoice(lang), systemImage: "doc.badge.plus")
                             }
-                            .buttonStyle(.borderedProminent)
+                            .buttonStyle(.facio(.primary))
                         }
                     }
                 }
@@ -425,7 +423,7 @@ struct TimeHubView: View {
                         .font(.headline)
                         .lineLimit(2)
                     Text([group.clientName, group.projectName].filter { !$0.isEmpty }.joined(separator: " / "))
-                        .font(.caption)
+                        .font(FacioFont.caption)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
                 }
@@ -444,22 +442,17 @@ struct TimeHubView: View {
                 Label(formatDuration(group.stats.totalSeconds), systemImage: "clock")
                 Spacer()
                 Text(currency.formatAccounting(group.stats.estimatedAmount, lang: numberFormat))
-                    .font(.caption.monospacedDigit())
+                    .font(FacioFont.metaValue)
                     .foregroundStyle(.secondary)
             }
-            .font(.caption)
+            .font(FacioFont.caption)
 
             ProgressView(value: progressValue(group))
                 .tint(Color.intentSuccess)
         }
         .padding(FacioLayout.space12)
         .frame(maxWidth: .infinity, minHeight: 135, alignment: .topLeading)
-        .background(Color.surfaceTile)
-        .overlay(
-            RoundedRectangle(cornerRadius: FacioLayout.radiusPanel)
-                .strokeBorder(Color.borderSubtle, lineWidth: 1)
-        )
-        .clipShape(RoundedRectangle(cornerRadius: FacioLayout.radiusPanel))
+        .facioCardChrome(surface: .surfaceTile)
     }
 
     private func calendar(contexts: [TimeHubEntryContext], interval: DateInterval, now: Date) -> some View {
@@ -510,10 +503,10 @@ struct TimeHubView: View {
         let stats = TimeHubAggregationService.stats(for: contexts, now: now)
         return VStack(alignment: .leading, spacing: FacioLayout.space8) {
             Text(day.formatted(.dateTime.weekday(.abbreviated).day()))
-                .font(.caption)
+                .font(FacioFont.caption)
                 .fontWeight(.semibold)
             Text(formatDuration(stats.totalSeconds))
-                .font(.caption.monospacedDigit())
+                .font(FacioFont.metaValue)
                 .foregroundStyle(.secondary)
             ForEach(contexts.prefix(4)) { context in
                 calendarBlock(context, now: now)
@@ -535,7 +528,7 @@ struct TimeHubView: View {
         let stats = TimeHubAggregationService.stats(for: contexts, now: now)
         return VStack(alignment: .leading, spacing: FacioLayout.space6) {
             Text(day.formatted(.dateTime.day()))
-                .font(.caption)
+                .font(FacioFont.caption)
                 .fontWeight(.semibold)
             if stats.totalSeconds > 0 {
                 Text(formatDuration(stats.totalSeconds))
@@ -570,7 +563,7 @@ struct TimeHubView: View {
     private func calendarBlock(_ context: TimeHubEntryContext, now: Date) -> some View {
         VStack(alignment: .leading, spacing: FacioLayout.space2) {
             Text(context.entry.notes.isEmpty ? TimeHubAggregationService.taskTitle(for: context.entry) : context.entry.notes)
-                .font(.caption2)
+                .font(FacioFont.captionSmall)
                 .fontWeight(.medium)
                 .lineLimit(2)
             Text("\(timeRange(context.entry)) - \(formatDuration(context.durationSeconds(at: now)))")
@@ -602,12 +595,12 @@ struct TimeHubView: View {
                         VStack(alignment: .leading, spacing: FacioLayout.space8) {
                             HStack {
                                 Text(group.date.formattedDate(for: lang))
-                                    .font(.headline)
+                                    .font(FacioFont.sectionTitle)
                                 Text(formatDuration(group.stats.totalSeconds))
-                                    .font(.subheadline.monospacedDigit())
+                                    .font(FacioFont.rowValue)
                                     .foregroundStyle(.secondary)
                                 Text(currency.formatAccounting(group.stats.estimatedAmount, lang: numberFormat))
-                                    .font(.subheadline.monospacedDigit())
+                                    .font(FacioFont.rowValue)
                                     .foregroundStyle(.secondary)
                                 Spacer()
                                 if group.stats.uninvoicedSeconds > 0 {
@@ -668,17 +661,16 @@ struct TimeHubView: View {
         HStack(spacing: FacioLayout.space10) {
             VStack(alignment: .leading, spacing: FacioLayout.space2) {
                 Text(context.entry.notes.isEmpty ? TimeHubAggregationService.taskTitle(for: context.entry) : context.entry.notes)
-                    .font(.subheadline)
-                    .fontWeight(.medium)
+                    .font(FacioFont.rowTitle)
                     .lineLimit(1)
                 Text([context.clientName, context.entry.displayProject, context.entry.displayTask].filter { !$0.isEmpty }.joined(separator: " / "))
-                    .font(.caption)
+                    .font(FacioFont.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
             }
             Spacer()
             Text(formatDuration(context.durationSeconds(at: now)))
-                .font(.caption.monospacedDigit())
+                .font(FacioFont.metaValue)
             statusBadge(context.entry.isBillable ? L10n.billable(lang) : L10n.nonBillable(lang), color: context.entry.isBillable ? .intentSuccess : .secondary)
         }
         .padding(FacioLayout.space8)
@@ -690,21 +682,20 @@ struct TimeHubView: View {
         HStack(spacing: FacioLayout.space12) {
             VStack(alignment: .leading, spacing: FacioLayout.space2) {
                 Text(title.isEmpty ? L10n.noClient(lang) : title)
-                    .font(.subheadline)
-                    .fontWeight(.medium)
+                    .font(FacioFont.rowTitle)
                     .lineLimit(1)
                 Text(subtitle)
-                    .font(.caption)
+                    .font(FacioFont.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
             }
             Spacer()
             VStack(alignment: .trailing, spacing: FacioLayout.space2) {
                 Text(formatDuration(stats.totalSeconds))
-                    .font(.subheadline.monospacedDigit())
+                    .font(FacioFont.rowValue)
                     .fontWeight(.semibold)
                 Text(currency.formatAccounting(stats.estimatedAmount, lang: numberFormat))
-                    .font(.caption.monospacedDigit())
+                    .font(FacioFont.metaValue)
                     .foregroundStyle(.secondary)
             }
         }
@@ -788,7 +779,7 @@ struct TimeHubView: View {
 
     private func statusBadge(_ text: String, color: Color) -> some View {
         Text(text)
-            .font(.caption2)
+            .font(FacioFont.captionSmall)
             .padding(.horizontal, FacioLayout.space6)
             .padding(.vertical, FacioLayout.space4)
             .background(color.opacity(0.12))
@@ -815,10 +806,9 @@ private struct TimeHubEntryRow: View {
                 .frame(width: 22)
             VStack(alignment: .leading, spacing: FacioLayout.space4) {
                 Text(title)
-                    .font(.subheadline)
-                    .fontWeight(.medium)
+                    .font(FacioFont.rowTitle)
                 Text([context.clientName, context.entry.displayProject, context.entry.displayTask].filter { !$0.isEmpty }.joined(separator: " / "))
-                    .font(.caption)
+                    .font(FacioFont.caption)
                     .foregroundStyle(.secondary)
                 HStack(spacing: FacioLayout.space6) {
                     badge(context.entry.isBillable ? L10n.billable(lang) : L10n.nonBillable(lang), color: context.entry.isBillable ? .intentSuccess : .secondary)
@@ -831,11 +821,11 @@ private struct TimeHubEntryRow: View {
             Spacer()
             VStack(alignment: .trailing, spacing: FacioLayout.space2) {
                 Text(DurationFormatter.clock(context.durationSeconds(at: now)))
-                    .font(.subheadline.monospacedDigit())
+                    .font(FacioFont.rowValue)
                     .fontWeight(.semibold)
                 if context.entry.isBillable {
                     Text((context.entry.currencySnapshot ?? defaultCurrency).formatAccounting(context.estimatedAmount(at: now), lang: numberFormat))
-                        .font(.caption.monospacedDigit())
+                        .font(FacioFont.metaValue)
                         .foregroundStyle(.secondary)
                 }
             }
@@ -867,8 +857,7 @@ private struct TimeHubEntryRow: View {
             }
         }
         .padding(FacioLayout.space10)
-        .background(Color.surfaceTile)
-        .clipShape(RoundedRectangle(cornerRadius: FacioLayout.radiusPanel))
+        .facioCardChrome(surface: .surfaceTile)
     }
 
     private var title: String {
@@ -879,7 +868,7 @@ private struct TimeHubEntryRow: View {
 
     private func badge(_ text: String, color: Color) -> some View {
         Text(text)
-            .font(.caption2)
+            .font(FacioFont.captionSmall)
             .padding(.horizontal, FacioLayout.space6)
             .padding(.vertical, FacioLayout.space4)
             .background(color.opacity(0.12))
@@ -920,15 +909,15 @@ private struct TimeHubEntryEditor: View {
         VStack(alignment: .leading, spacing: FacioLayout.space10) {
             HStack(spacing: FacioLayout.space10) {
                 TextField(L10n.timeEntryDescription(lang), text: $notes)
-                    .textFieldStyle(.roundedBorder)
+                    .facioField()
                 TextField(L10n.project(lang), text: $projectName)
-                    .textFieldStyle(.roundedBorder)
+                    .facioField()
                 TextField(L10n.task(lang), text: $taskName)
-                    .textFieldStyle(.roundedBorder)
+                    .facioField()
             }
             HStack(spacing: FacioLayout.space10) {
                 TextField(L10n.tags(lang), text: $tagsText)
-                    .textFieldStyle(.roundedBorder)
+                    .facioField()
                 Toggle(L10n.billable(lang), isOn: $isBillable)
                     .toggleStyle(.switch)
                 DatePicker(L10n.startDate(lang), selection: $startedAt)
@@ -944,12 +933,11 @@ private struct TimeHubEntryEditor: View {
                 Spacer()
                 Button(L10n.cancel(lang), action: onClose)
                 Button(L10n.save(lang), action: save)
-                    .buttonStyle(.borderedProminent)
+                    .buttonStyle(.facio(.primary))
             }
         }
         .padding(FacioLayout.space10)
-        .background(Color.surfaceField)
-        .clipShape(RoundedRectangle(cornerRadius: FacioLayout.radiusPanel))
+        .facioCardChrome(surface: .surfaceField)
     }
 
     private func save() {
@@ -1005,7 +993,7 @@ private struct TimeHubManualEntrySheet: View {
         VStack(alignment: .leading, spacing: FacioLayout.space16) {
             HStack {
                 Label(L10n.timeHubAddManualEntry(lang), systemImage: "plus")
-                    .font(.headline)
+                    .font(FacioFont.sectionTitle)
                 Spacer()
                 Button(L10n.close(lang)) { dismiss() }
             }
@@ -1017,15 +1005,15 @@ private struct TimeHubManualEntrySheet: View {
             }
 
             TextField(L10n.timeEntryDescription(lang), text: $notes)
-                .textFieldStyle(.roundedBorder)
+                .facioField()
             HStack {
                 TextField(L10n.project(lang), text: $projectName)
-                    .textFieldStyle(.roundedBorder)
+                    .facioField()
                 TextField(L10n.task(lang), text: $taskName)
-                    .textFieldStyle(.roundedBorder)
+                    .facioField()
             }
             TextField(L10n.tags(lang), text: $tagsText)
-                .textFieldStyle(.roundedBorder)
+                .facioField()
 
             HStack {
                 DatePicker(L10n.period(lang), selection: $date, displayedComponents: [.date])
@@ -1033,7 +1021,7 @@ private struct TimeHubManualEntrySheet: View {
                 DatePicker(L10n.endDate(lang), selection: $endTime, displayedComponents: [.hourAndMinute])
             }
             TextField(L10n.durationExamples(lang), text: $durationInput)
-                .textFieldStyle(.roundedBorder)
+                .facioField()
             Toggle(L10n.billable(lang), isOn: $isBillable)
                 .toggleStyle(.switch)
 
@@ -1045,7 +1033,7 @@ private struct TimeHubManualEntrySheet: View {
                 Spacer()
                 Button(L10n.cancel(lang)) { dismiss() }
                 Button(L10n.addTimeEntry(lang), action: save)
-                    .buttonStyle(.borderedProminent)
+                    .buttonStyle(.facio(.primary))
                     .disabled(selectedTimesheet == nil)
             }
         }

--- a/Facio/Views/TimeHub/TimeHubView.swift
+++ b/Facio/Views/TimeHub/TimeHubView.swift
@@ -420,7 +420,7 @@ struct TimeHubView: View {
             HStack(alignment: .top) {
                 VStack(alignment: .leading, spacing: FacioLayout.space2) {
                     Text(group.title == "untitled" ? L10n.untitledTask(lang) : group.title)
-                        .font(.headline)
+                        .font(FacioFont.sectionTitle)
                         .lineLimit(2)
                     Text([group.clientName, group.projectName].filter { !$0.isEmpty }.joined(separator: " / "))
                         .font(FacioFont.caption)

--- a/Facio/Views/Timesheet/TimeTrackerPanel.swift
+++ b/Facio/Views/Timesheet/TimeTrackerPanel.swift
@@ -146,8 +146,7 @@ struct TimeTrackerPanel: View {
                     } label: {
                         Label(L10n.stopTimer(lang), systemImage: "stop.fill")
                     }
-                    .buttonStyle(.borderedProminent)
-                    .tint(Color.intentDanger)
+                    .buttonStyle(.facio(.destructive))
                 } else {
                     Text("00:00:00")
                         .font(FacioFont.clock)
@@ -181,7 +180,7 @@ struct TimeTrackerPanel: View {
                 if let liveStartDateRange {
                     HStack(spacing: FacioLayout.space12) {
                         Label(L10n.startDate(lang), systemImage: "clock.arrow.circlepath")
-                            .font(.subheadline)
+                            .font(FacioFont.fieldLabel)
                             .foregroundStyle(.secondary)
                         DatePicker(
                             L10n.startDate(lang),
@@ -192,7 +191,7 @@ struct TimeTrackerPanel: View {
                         .labelsHidden()
                         .frame(maxWidth: 280)
                         Text(L10n.startedEarlierHint(lang))
-                            .font(.caption)
+                            .font(FacioFont.caption)
                             .foregroundStyle(.secondary)
                         Spacer()
                     }
@@ -205,7 +204,7 @@ struct TimeTrackerPanel: View {
                     } label: {
                         Label(L10n.startTimer(lang), systemImage: "play.fill")
                     }
-                    .buttonStyle(.borderedProminent)
+                    .buttonStyle(.facio(.primary))
                     .disabled(!canStartLiveTimer)
 
                     Toggle(L10n.startedEarlier(lang), isOn: $usesCustomStartDate)
@@ -235,15 +234,15 @@ struct TimeTrackerPanel: View {
         VStack(alignment: .leading, spacing: FacioLayout.space10) {
             HStack(spacing: FacioLayout.space10) {
                 TextField(L10n.timeEntryDescription(lang), text: $notes)
-                    .textFieldStyle(.roundedBorder)
+                    .facioField()
                 TextField(L10n.project(lang), text: $projectName)
-                    .textFieldStyle(.roundedBorder)
+                    .facioField()
                 TextField(L10n.task(lang), text: $taskName)
-                    .textFieldStyle(.roundedBorder)
+                    .facioField()
             }
             HStack(spacing: FacioLayout.space10) {
                 TextField(L10n.tags(lang), text: $tagsText)
-                    .textFieldStyle(.roundedBorder)
+                    .facioField()
                 Toggle(L10n.billable(lang), isOn: $isBillable)
                     .toggleStyle(.switch)
                 Spacer()
@@ -255,15 +254,15 @@ struct TimeTrackerPanel: View {
         VStack(alignment: .leading, spacing: FacioLayout.space10) {
             HStack(spacing: FacioLayout.space10) {
                 TextField(L10n.timeEntryDescription(lang), text: entryStringBinding(entry, \.notes))
-                    .textFieldStyle(.roundedBorder)
+                    .facioField()
                 TextField(L10n.project(lang), text: entryStringBinding(entry, \.projectName))
-                    .textFieldStyle(.roundedBorder)
+                    .facioField()
                 TextField(L10n.task(lang), text: entryStringBinding(entry, \.taskName))
-                    .textFieldStyle(.roundedBorder)
+                    .facioField()
             }
             HStack(spacing: FacioLayout.space10) {
                 TextField(L10n.tags(lang), text: entryStringBinding(entry, \.tagsText))
-                    .textFieldStyle(.roundedBorder)
+                    .facioField()
                 Toggle(L10n.billable(lang), isOn: entryBoolBinding(entry, \.isBillable))
                     .toggleStyle(.switch)
                 Spacer()
@@ -287,18 +286,18 @@ struct TimeTrackerPanel: View {
                 DatePicker(L10n.endDate(lang), selection: $manualEndTime, displayedComponents: [.hourAndMinute])
                     .labelsHidden()
                 TextField(L10n.duration(lang), text: $manualDurationInput)
-                    .textFieldStyle(.roundedBorder)
+                    .facioField()
                     .frame(width: 110)
                 Button {
                     addManualEntry()
                 } label: {
                     Label(L10n.addTimeEntry(lang), systemImage: "plus")
                 }
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(.facio(.primary))
                 Spacer()
             }
             Text(L10n.durationExamples(lang))
-                .font(.caption)
+                .font(FacioFont.caption)
                 .foregroundStyle(.secondary)
         }
     }
@@ -315,7 +314,7 @@ struct TimeTrackerPanel: View {
             .frame(width: 260)
 
             TextField(L10n.searchTimeEntries(lang), text: $searchText)
-                .textFieldStyle(.roundedBorder)
+                .facioField()
 
             Button {
                 inputMode = .manual
@@ -411,12 +410,12 @@ struct TimeTrackerPanel: View {
                     VStack(alignment: .leading, spacing: FacioLayout.space6) {
                         HStack {
                             Text(dateLabel(dateString))
-                                .font(.caption)
+                                .font(FacioFont.caption)
                                 .fontWeight(.semibold)
                                 .foregroundStyle(.secondary)
                                 .textCase(.uppercase)
                             Text(DurationFormatter.clock(totalDuration(for: entries(for: dateString), now: now)))
-                                .font(.caption.monospacedDigit())
+                                .font(FacioFont.metaValue)
                                 .foregroundStyle(.secondary)
                         }
 
@@ -698,8 +697,7 @@ private struct TimeEntryRow: View {
 
             VStack(alignment: .leading, spacing: FacioLayout.space4) {
                 Text(primaryTitle)
-                    .font(.subheadline)
-                    .fontWeight(.medium)
+                    .font(FacioFont.rowTitle)
                     .lineLimit(1)
                 HStack(spacing: FacioLayout.space8) {
                     if !clientName.isEmpty {
@@ -713,7 +711,7 @@ private struct TimeEntryRow: View {
                     }
                     Text(timeRange)
                 }
-                .font(.caption)
+                .font(FacioFont.caption)
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
                 HStack(spacing: FacioLayout.space6) {
@@ -733,11 +731,11 @@ private struct TimeEntryRow: View {
 
             VStack(alignment: .trailing, spacing: FacioLayout.space2) {
                 Text(DurationFormatter.clock(entry.duration(at: now)))
-                    .font(.subheadline.monospacedDigit())
+                    .font(FacioFont.rowValue)
                     .fontWeight(.semibold)
                 if entry.isBillable {
                     Text(estimatedAmount)
-                        .font(.caption)
+                        .font(FacioFont.caption)
                         .foregroundStyle(.secondary)
                 }
             }
@@ -768,8 +766,7 @@ private struct TimeEntryRow: View {
             }
         }
         .padding(FacioLayout.space10)
-        .background(Color.surfaceTile)
-        .clipShape(RoundedRectangle(cornerRadius: FacioLayout.radiusPanel))
+        .facioCardChrome(surface: .surfaceTile)
     }
 
     private var primaryTitle: String {
@@ -799,7 +796,7 @@ private struct TimeEntryRow: View {
 
     private func statusBadge(_ text: String, color: Color) -> some View {
         Text(text)
-            .font(.caption2)
+            .font(FacioFont.captionSmall)
             .padding(.horizontal, FacioLayout.space6)
             .padding(.vertical, FacioLayout.space4)
             .background(color.opacity(0.12))
@@ -850,15 +847,15 @@ private struct TimeEntryInlineEditor: View {
         VStack(alignment: .leading, spacing: FacioLayout.space10) {
             HStack(spacing: FacioLayout.space10) {
                 TextField(L10n.timeEntryDescription(lang), text: $notes)
-                    .textFieldStyle(.roundedBorder)
+                    .facioField()
                 TextField(L10n.project(lang), text: $projectName)
-                    .textFieldStyle(.roundedBorder)
+                    .facioField()
                 TextField(L10n.task(lang), text: $taskName)
-                    .textFieldStyle(.roundedBorder)
+                    .facioField()
             }
             HStack(spacing: FacioLayout.space10) {
                 TextField(L10n.tags(lang), text: $tagsText)
-                    .textFieldStyle(.roundedBorder)
+                    .facioField()
                 Toggle(L10n.billable(lang), isOn: $isBillable)
                     .toggleStyle(.switch)
                 DatePicker(L10n.startDate(lang), selection: $startedAt, in: editableDateRange)
@@ -870,7 +867,7 @@ private struct TimeEntryInlineEditor: View {
             HStack {
                 if let statusText {
                     Text(statusText)
-                        .font(.caption)
+                        .font(FacioFont.caption)
                         .foregroundStyle(.secondary)
                 }
                 Spacer()
@@ -878,12 +875,11 @@ private struct TimeEntryInlineEditor: View {
                 Button(L10n.save(lang)) {
                     save()
                 }
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(.facio(.primary))
             }
         }
         .padding(FacioLayout.space10)
-        .background(Color.surfaceField)
-        .clipShape(RoundedRectangle(cornerRadius: FacioLayout.radiusPanel))
+        .facioCardChrome(surface: .surfaceField)
         .onChange(of: startedAt) { _, newStart in
             if endedAt < newStart {
                 endedAt = newStart

--- a/Facio/Views/Timesheet/TimesheetEditorView.swift
+++ b/Facio/Views/Timesheet/TimesheetEditorView.swift
@@ -129,10 +129,9 @@ struct TimesheetEditorView: View {
             HStack(alignment: .center, spacing: FacioLayout.space16) {
                 VStack(alignment: .leading, spacing: FacioLayout.space6) {
                     Text(timesheet.periodLabel(for: lang))
-                        .font(.title2)
-                        .fontWeight(.semibold)
+                        .font(FacioFont.heroTitle)
                     Text(timesheet.clientDisplayName.isEmpty ? L10n.noClient(lang) : timesheet.clientDisplayName)
-                        .font(.subheadline)
+                        .font(FacioFont.screenSubtitle)
                         .foregroundStyle(timesheet.clientDisplayName.isEmpty ? .tertiary : .secondary)
                 }
 
@@ -499,6 +498,7 @@ struct TimesheetEditorView: View {
                 .font(FacioFont.fieldLabel)
                 .foregroundStyle(.secondary)
             DecimalField(placeholder: placeholder, value: value)
+                .density(.regular)
         }
     }
 

--- a/Facio/Views/Timesheet/TimesheetEditorView.swift
+++ b/Facio/Views/Timesheet/TimesheetEditorView.swift
@@ -140,33 +140,30 @@ struct TimesheetEditorView: View {
 
                 VStack(alignment: .trailing, spacing: FacioLayout.space4) {
                     Text(L10n.totalHours(lang))
-                        .font(.caption)
+                        .font(FacioFont.caption)
                         .foregroundStyle(.secondary)
                     Text("\(heures.formatted2Decimals(for: numberFormat))h")
-                        .font(.title3.monospacedDigit())
-                        .fontWeight(.bold)
+                        .font(FacioFont.amountEmphasis)
                 }
 
                 VStack(alignment: .trailing, spacing: FacioLayout.space4) {
                     Text(L10n.grossTotal(lang))
-                        .font(.caption)
+                        .font(FacioFont.caption)
                         .foregroundStyle(.secondary)
                     Text(brut.formatted2Decimals(for: numberFormat))
-                        .font(.title3.monospacedDigit())
-                        .fontWeight(.bold)
+                        .font(FacioFont.amountEmphasis)
                 }
 
                 VStack(alignment: .trailing, spacing: FacioLayout.space4) {
                     Text(L10n.netTotal(lang))
-                        .font(.caption)
+                        .font(FacioFont.caption)
                         .foregroundStyle(.secondary)
                     Text(net.formatted2Decimals(for: numberFormat))
-                        .font(.title3.monospacedDigit())
-                        .fontWeight(.bold)
+                        .font(FacioFont.amountEmphasis)
                 }
 
                 Text(timesheet.hasGeneratedInvoice ? L10n.invoiced(lang) : L10n.notInvoiced(lang))
-                    .font(.caption)
+                    .font(FacioFont.caption)
                     .fontWeight(.medium)
                     .padding(.horizontal, FacioLayout.space8)
                     .padding(.vertical, FacioLayout.space4)
@@ -202,7 +199,7 @@ struct TimesheetEditorView: View {
                     } label: {
                         Label(L10n.updatePeriodDates(lang), systemImage: "calendar.badge.clock")
                     }
-                    .buttonStyle(.borderedProminent)
+                    .buttonStyle(.facio(.primary))
                     .disabled(!rangeDraftHasChanges || rangeDraftOverlaps)
                 }
 
@@ -356,7 +353,7 @@ struct TimesheetEditorView: View {
     private var hourInputModeControl: some View {
         HStack(spacing: FacioLayout.space12) {
             Label(L10n.hourInputMode(lang), systemImage: "clock.badge")
-                .font(.subheadline)
+                .font(FacioFont.fieldLabel)
                 .foregroundStyle(.secondary)
 
             Picker("", selection: $hourInputMode) {
@@ -388,22 +385,22 @@ struct TimesheetEditorView: View {
                 HStack {
                     VStack(alignment: .leading, spacing: FacioLayout.space2) {
                         Text(L10n.week(lang, number: week.numero))
-                            .font(.headline)
+                            .font(FacioFont.sectionTitle)
                         Text(week.label(for: lang))
-                            .font(.caption)
+                            .font(FacioFont.caption)
                             .foregroundStyle(.secondary)
                     }
                     Spacer()
                     HStack(spacing: FacioLayout.space16) {
                         Label("\(heuresMoisSemaine.formatted2Decimals(for: numberFormat))h", systemImage: "clock")
-                            .font(.subheadline.monospacedDigit())
+                            .font(FacioFont.rowValue)
                             .fontWeight(.medium)
                         Text(L10n.normalHoursShort(lang, value: normSemaine.formatted2Decimals(for: numberFormat)))
-                            .font(.caption.monospacedDigit())
+                            .font(FacioFont.metaValue)
                             .foregroundStyle(Color.intentInfo)
                         if supSemaine > 0 {
                             Text(L10n.overtimeHoursShort(lang, value: supSemaine.formatted2Decimals(for: numberFormat)))
-                                .font(.caption.monospacedDigit())
+                                .font(FacioFont.metaValue)
                                 .foregroundStyle(Color.intentWarning)
                                 .fontWeight(.medium)
                         }
@@ -411,7 +408,7 @@ struct TimesheetEditorView: View {
                         let coutSemaine = normSemaine * timesheet.tauxNormal
                             + supSemaine * timesheet.tauxSupplementaire
                         Text(coutSemaine.formatted2Decimals(for: numberFormat))
-                            .font(.subheadline.monospacedDigit())
+                            .font(FacioFont.rowValue)
                             .fontWeight(.semibold)
                             .foregroundStyle(Color.intentSuccess)
                     }
@@ -426,10 +423,10 @@ struct TimesheetEditorView: View {
                         let hasTimerEntries = timesheet.hasTimeEntries(on: jour.dateString)
                         VStack(spacing: FacioLayout.space4) {
                             Text(jour.jourSemaine.shortLabel(for: lang))
-                                .font(.caption2)
+                                .font(FacioFont.captionSmall)
                                 .foregroundStyle(.secondary)
                             Text("\(jour.jourDuMois)")
-                                .font(.system(.caption, design: .monospaced))
+                                .font(FacioFont.monoCaption)
                                 .foregroundStyle(estDansMois ? .primary : .tertiary)
                             TimeField(
                                 placeholder: L10n.hourInputPlaceholder(lang, mode: hourInputMode),
@@ -499,7 +496,7 @@ struct TimesheetEditorView: View {
     private func settingsField(_ label: String, placeholder: String, value: Binding<Decimal>) -> some View {
         VStack(alignment: .leading, spacing: FacioLayout.space4) {
             Text(label)
-                .font(.subheadline)
+                .font(FacioFont.fieldLabel)
                 .foregroundStyle(.secondary)
             DecimalField(placeholder: placeholder, value: value)
         }

--- a/Facio/Views/Timesheet/TimesheetListView.swift
+++ b/Facio/Views/Timesheet/TimesheetListView.swift
@@ -175,7 +175,7 @@ struct TimesheetListView: View {
     private var newPeriodPopover: some View {
         VStack(spacing: FacioLayout.space16) {
             Text(L10n.newPeriod(lang))
-                .font(.headline)
+                .font(FacioFont.sectionTitle)
 
             Picker("", selection: $newPeriodMode) {
                 Text(L10n.monthlyPeriod(lang)).tag(NewTimesheetPeriodMode.month)
@@ -230,7 +230,7 @@ struct TimesheetListView: View {
 
             HStack(spacing: FacioLayout.space12) {
                 Text(L10n.selectClientForPeriod(lang))
-                    .font(.subheadline)
+                    .font(FacioFont.fieldLabel)
                     .foregroundStyle(.secondary)
                 Spacer()
                 Picker(L10n.selectClientForPeriod(lang), selection: $selectedClientId) {
@@ -256,13 +256,13 @@ struct TimesheetListView: View {
                 Button(L10n.cancel(lang)) {
                     showNewPeriod = false
                 }
-                .buttonStyle(.bordered)
+                .buttonStyle(.facio(.secondary))
 
                 Button(L10n.create(lang)) {
                     creerPeriode(client: selectedClient)
                     showNewPeriod = false
                 }
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(.facio(.primary))
                 .disabled(selectedClient == nil || selectedRangeOverlaps)
             }
         }
@@ -336,27 +336,27 @@ private struct TimesheetRowView: View {
                     Spacer()
                     if brut > 0 {
                         Text(brut.formatted2Decimals(for: numberFormat))
-                            .font(.subheadline.monospacedDigit())
+                            .font(FacioFont.rowValue)
                             .fontWeight(.medium)
                             .foregroundStyle(.secondary)
                     }
                 }
                 HStack(spacing: FacioLayout.space8) {
                     Text(timesheet.clientDisplayName.isEmpty ? L10n.noClient(lang) : timesheet.clientDisplayName)
-                        .font(.caption)
+                        .font(FacioFont.caption)
                         .foregroundStyle(timesheet.clientDisplayName.isEmpty ? .tertiary : .secondary)
                         .lineLimit(1)
                     Text("\(heuresMois.formatted2Decimals(for: numberFormat))h")
-                        .font(.caption.monospacedDigit())
+                        .font(FacioFont.metaValue)
                         .foregroundStyle(.secondary)
                     if heuresSup > 0 {
                         Text(L10n.overtimeHoursShort(lang, value: heuresSup.formatted2Decimals(for: numberFormat)))
-                            .font(.caption)
+                            .font(FacioFont.caption)
                             .foregroundStyle(Color.intentWarning)
                     }
                     if timesheet.hasGeneratedInvoice {
                         Text(L10n.invoiced(lang))
-                            .font(.caption)
+                            .font(FacioFont.caption)
                             .foregroundStyle(Color.intentSuccess)
                     }
                 }


### PR DESCRIPTION
## Contexte

PR2 du chantier UI/UX (plan validé). Le design system livré en #75 (tokens, composants Facio*) n'était presque pas adopté : 85 `.textFieldStyle(.roundedBorder)`, 16 boutons natifs, ~190 `.font()` hors tokens, styles dupliqués. Cette PR diffuse le design system dans les 35 fichiers de vues.

> **Empilée sur #79** (`fix/ui-fragilites-email`) — à recibler sur `main` après le merge de #79.

## Socle (commit `refactor(design)`)

- **`.facioField(error:density:)`** : ViewModifier de chrome de champ (fond, focus ring, erreur inline en `regular`, bordure seule en `compact`) appliqué aux `TextField`/`SecureField` natifs. `FacioTextField` refactoré dessus.
- **`\.facioAccent`** : l'accent de marque (CompanyInfo) devient ambiant, injecté à la racine des 2 scènes + `.tint` global — `FacioButtonStyle` et `FacioButton` ne dépendent plus de `DataStore`.
- **`.facioCardChrome(surface:radius:)`** : chrome de carte unifié, remplace les blocs `background+overlay+clipShape` dupliqués.
- **6 tokens typo nouveaux** : `fieldLabel`, `subsectionTitle`, `rowValue`, `metaValue`, `heroTitle`, `heroTotal` + règle de liste blanche documentée en tête de `FacioTypography.swift`.

## Migration (4 commits `impr(...)` par zone + `fix(i18n)`)

| Zone | Champs | Boutons | Typos |
|---|---|---|---|
| Settings (10 fichiers) | 21 | 4 | 23 |
| Documents (10 fichiers) | 18 | 2 | 41 |
| Timesheet + TimeHub (5 fichiers) | ~35 | 10 | ~30 |
| Clients + Dashboard + Sidebar | 8 | 2 | ~15 |

- `fix(i18n):` le taux de TVA est désormais formaté selon le format de nombre (« 5,5 % » / « 5.5% ») au lieu du `NSDecimalNumber` brut.
- Gates : `grep roundedBorder|buttonStyle(.bordered` sur Views/ → **0** ; les ~40 `.font()` natifs restants relèvent de la liste blanche documentée (glyphes SF Symbols, décoratif, libellés de boutons custom).

## Revue adversariale (3 reviewers + réfutation) — corrigée avant push

- Total héros de l'éditeur : token `heroTotal` créé (le mapping initial perdait 5 pt) ✔
- `.facioField` retiré du Form `.grouped` d'AddSignatureSheet (double chrome) ✔
- `DecimalField.density(.regular)` dans les formulaires (taux de change, paramètres timesheet) ✔
- Header de l'éditeur timesheet harmonisé avec celui des documents (`heroTitle`/`screenSubtitle`) ✔

**Changements visuels assumés** : headers d'écran `.largeTitle` → `screenTitle` (22 pt bold) ; montants gagnent le poids medium de `FacioFont.amount` ; `.facioCardChrome` ajoute une bordure `borderSubtle` (8 %) sur quelques tuiles qui n'en avaient pas ; boutons par défaut de SyncSettings hiérarchisés en `.facio(.primary/.secondary)`.

## Vérification

- `swift build` : 0 erreur, 0 warning · `--run-regressions` : **76/76** à chaque commit.
- Passe visuelle recommandée avant merge : Réglages > Personnalisation (changer l'accent → boutons/tint suivent), éditeur de facture (champs, lignes, totaux), timesheet (grille d'heures), ⌘K.