### PR TITLE
impr(pdf): rafraîchir la mise en page de la facture

### DIFF
--- a/Facio/Diagnostics/RegressionSuite.swift
+++ b/Facio/Diagnostics/RegressionSuite.swift
@@ -1,6 +1,7 @@
 #if FACIO_REGRESSION_TESTS
 import Darwin
 import Foundation
+import PDFKit
 
 @MainActor
 enum FacioRegressionSuite {
@@ -114,8 +115,28 @@ enum FacioRegressionSuite {
         RegressionCase(name: "email safe filename strips unsafe characters", run: emailSafeFilenameStripsUnsafeCharacters),
         RegressionCase(name: "attachment import copies file and records metadata", run: attachmentImportCopiesFileAndRecordsMetadata),
         RegressionCase(name: "attachment duplication reports missing source files", run: attachmentDuplicationReportsMissingSourceFiles),
-        RegressionCase(name: "attachment urls expose only existing files", run: attachmentURLsExposeOnlyExistingFiles)
+        RegressionCase(name: "attachment urls expose only existing files", run: attachmentURLsExposeOnlyExistingFiles),
+        RegressionCase(name: "pdf generation paginates long invoices", run: pdfGenerationPaginatesLongInvoices)
     ]
+
+    private static func pdfGenerationPaginatesLongInvoices() throws {
+        let company = try JSONDecoder().decode(CompanyInfo.self, from: Data(#"{"nom":"Facio SAS"}"#.utf8))
+
+        let short = Document(type: .facture, number: "Facture_2026_01")
+        short.ajouterLigne(LineItem(designation: "Dev", quantite: 1, prixUnitaire: 100, tauxTVA: 20))
+        let shortData = PDFGenerator(document: short, company: company).generate()
+        try expect(!shortData.isEmpty, "short invoice should produce PDF data")
+        let shortDoc = try require(PDFDocument(data: shortData), "short invoice PDF should parse")
+        try expectEqual(shortDoc.pageCount, 1)
+
+        let long = Document(type: .facture, number: "Facture_2026_02")
+        for i in 1...60 {
+            long.ajouterLigne(LineItem(designation: "Prestation \(i)", quantite: 1, prixUnitaire: 100, tauxTVA: 20))
+        }
+        let longData = PDFGenerator(document: long, company: company).generate()
+        let longDoc = try require(PDFDocument(data: longData), "long invoice PDF should parse")
+        try expect(longDoc.pageCount >= 2, "a 60-line invoice should span at least 2 pages, got \(longDoc.pageCount)")
+    }
 
     private static func decimalHourInputKeepsDecimalFractions() throws {
         try expectDecimal(TimesheetHourInputParser.parse("6,5", mode: .decimal), equals: "6.5")

--- a/Facio/PDF/PDFGenerator.swift
+++ b/Facio/PDF/PDFGenerator.swift
@@ -20,6 +20,7 @@ struct PDFGenerator {
     // Couleurs dynamiques (depuis CompanyInfo)
     private var themePrimary: NSColor { PDFLayout.themePrimary(from: company) }
     private var themeDark: NSColor { PDFLayout.themeDark(from: company) }
+    private var themeLight: NSColor { PDFLayout.themeLight(from: company) }
     private let maximumTextLength = 8_000
     private let maximumLineLength = 1_000
     private let maximumLogoBytes = 2_000_000
@@ -51,7 +52,7 @@ struct PDFGenerator {
         y += 15
 
         // 4. Totaux
-        y = ensurePageSpace(context, y: y, needed: 85)
+        y = ensurePageSpace(context, y: y, needed: 95)
         y = drawTotals(context, y: y)
         y += 25
 
@@ -359,9 +360,13 @@ struct PDFGenerator {
         let logoY = cy + 15
         drawAbstractLogo(context, centerX: logoX, centerY: logoY)
 
+        // Type de document en petites capitales au-dessus du numero
+        let typeLabel = document.type.label(for: lang).uppercased()
+        drawTextCenter(typeLabel, y: cy, font: PDFLayout.fontLabel, color: PDFLayout.textGray, context: context)
+
         // Titre centre — utilise le numero du document directement
         let title = document.number
-        drawTextCenter(title, y: cy + 15, font: PDFLayout.fontTitle, color: PDFLayout.textBlack, context: context)
+        drawTextCenter(title, y: cy + 13, font: PDFLayout.fontTitle, color: PDFLayout.textBlack, context: context)
 
         cy += 55
         return cy
@@ -396,13 +401,17 @@ struct PDFGenerator {
     private func drawDatesAndClient(_ context: CGContext, y: CGFloat) -> CGFloat {
         var cy = y
 
-        // Gauche : dates
+        // Gauche : dates — libellé gris discret, valeur en gras (hiérarchie lisible)
         let dateLabel = document.type == .facture ? L10n.invoiceDate(lang) : L10n.quoteDate(lang)
-        drawText("\(dateLabel)\(formatDate(document.dateCreation))",
-                 x: mL, y: cy, font: PDFLayout.fontBody, color: PDFLayout.textBlack, context: context)
+        drawText(dateLabel, x: mL, y: cy, font: PDFLayout.fontBody, color: PDFLayout.textGray, context: context)
+        drawText(formatDate(document.dateCreation),
+                 x: mL + textWidth(dateLabel, font: PDFLayout.fontBody), y: cy,
+                 font: PDFLayout.fontBodyBold, color: PDFLayout.textBlack, context: context)
         cy += 15
-        drawText("\(L10n.dueDate(lang))\(formatDate(document.dateEcheance))",
-                 x: mL, y: cy, font: PDFLayout.fontBodyBold, color: PDFLayout.textBlack, context: context)
+        drawText(L10n.dueDate(lang), x: mL, y: cy, font: PDFLayout.fontBody, color: PDFLayout.textGray, context: context)
+        drawText(formatDate(document.dateEcheance),
+                 x: mL + textWidth(L10n.dueDate(lang), font: PDFLayout.fontBody), y: cy,
+                 font: PDFLayout.fontBodyBold, color: PDFLayout.textBlack, context: context)
 
         // Droite : destinataire
         let blockRight = pW - mR
@@ -459,7 +468,7 @@ struct PDFGenerator {
         var tableStartY = y
 
         // Lignes
-        for (_, ligne) in document.lignesTriees.enumerated() {
+        for (index, ligne) in document.lignesTriees.enumerated() {
             if cy > pH - PDFLayout.marginBottom - 80 {
                 // Bordure du tableau avant nouvelle page
                 strokeRect(context, x: x, y: tableStartY, w: w, h: cy - tableStartY, color: themePrimary, lineWidth: 0.8)
@@ -469,13 +478,19 @@ struct PDFGenerator {
                 cy = drawTableHeader(context, headers: headers, colW: colW, x: x, w: w, y: cy)
             }
 
+            // Zebrage : une ligne sur deux sur fond theme tres leger (parite
+            // sur l'index global pour rester continu en multi-pages)
+            if index % 2 == 1 {
+                fillRect(context, x: x, y: cy, w: w, h: PDFLayout.tableRowHeight, color: themeLight)
+            }
+
             // Dessiner les separateurs verticaux verts legers
             var sepX = x
             for i in 0..<colW.count {
                 sepX += colW[i]
                 if i < colW.count - 1 {
                     strokeLine(context, x1: sepX, y1: cy, x2: sepX, y2: cy + PDFLayout.tableRowHeight,
-                               color: themePrimary.withAlphaComponent(0.3), width: 0.3)
+                               color: themePrimary.withAlphaComponent(0.2), width: 0.3)
                 }
             }
 
@@ -492,11 +507,11 @@ struct PDFGenerator {
             for (i, val) in vals.enumerated() {
                 if i == 0 {
                     // Designation alignee a gauche
-                    drawText(val, x: colX + 6, y: cy + 7,
+                    drawText(val, x: colX + 6, y: cy + 8,
                              font: PDFLayout.fontBody, color: PDFLayout.textBlack, context: context, maxWidth: colW[i] - 12)
                 } else {
                     // Nombres alignes a droite
-                    drawTextRight(val, rightX: colX + colW[i] - 6, y: cy + 7,
+                    drawTextRight(val, rightX: colX + colW[i] - 6, y: cy + 8,
                                   font: PDFLayout.fontBody, color: PDFLayout.textBlack, context: context, maxWidth: colW[i] - 12)
                 }
                 colX += colW[i]
@@ -521,10 +536,10 @@ struct PDFGenerator {
         var colX = x
         for (i, h) in headers.enumerated() {
             if i == 0 {
-                drawText(h, x: colX + 6, y: y + 9,
+                drawText(h, x: colX + 6, y: y + 10,
                          font: PDFLayout.fontTableHeader, color: PDFLayout.textWhite, context: context, maxWidth: colW[i] - 12)
             } else {
-                drawTextRight(h, rightX: colX + colW[i] - 6, y: y + 9,
+                drawTextRight(h, rightX: colX + colW[i] - 6, y: y + 10,
                               font: PDFLayout.fontTableHeader, color: PDFLayout.textWhite, context: context, maxWidth: colW[i] - 12)
             }
             colX += colW[i]
@@ -557,15 +572,18 @@ struct PDFGenerator {
                       font: PDFLayout.fontBody, color: PDFLayout.textBlack, context: context)
         cy += 18
 
-        // Ligne de separation
-        strokeLine(context, x1: labelRight - 30, y1: cy - 2, x2: valueRight, y2: cy - 2,
-                   color: themePrimary.withAlphaComponent(0.3), width: 0.5)
+        // Bandeau TTC : fond theme tres leger + filet superieur olive
+        let bandLeft = labelRight - 30
+        let bandHeight: CGFloat = 22
+        fillRect(context, x: bandLeft, y: cy - 4, w: valueRight - bandLeft + 4, h: bandHeight, color: themeLight)
+        strokeLine(context, x1: bandLeft, y1: cy - 4, x2: valueRight + 4, y2: cy - 4,
+                   color: themePrimary, width: 0.8)
 
-        drawTextRight(L10n.totalTTC(lang), rightX: labelRight, y: cy,
+        drawTextRight(L10n.totalTTC(lang), rightX: labelRight, y: cy + 1,
                       font: PDFLayout.fontTotalTTC, color: PDFLayout.textBlack, context: context)
-        drawTextRight("\(formatSpaced(document.totalTTC)) \(cur)", rightX: valueRight, y: cy,
+        drawTextRight("\(formatSpaced(document.totalTTC)) \(cur)", rightX: valueRight, y: cy + 1,
                       font: PDFLayout.fontTotalTTC, color: PDFLayout.textBlack, context: context)
-        cy += 16
+        cy += 20
 
         return cy
     }

--- a/Facio/PDF/PDFLayout.swift
+++ b/Facio/PDF/PDFLayout.swift
@@ -17,8 +17,8 @@ struct PDFLayout {
     static let contentWidth: CGFloat = pageWidth - marginLeft - marginRight
 
     // MARK: - Tableau
-    static let tableHeaderHeight: CGFloat = 28
-    static let tableRowHeight: CGFloat = 24
+    static let tableHeaderHeight: CGFloat = 30
+    static let tableRowHeight: CGFloat = 26
 
     // Colonnes du tableau (proportions)
     static let colDesignation: CGFloat = 0.40
@@ -31,7 +31,9 @@ struct PDFLayout {
     static let qrCodeSize: CGFloat = 120
 
     // MARK: - Polices (Helvetica / sans-serif)
-    static let fontTitle = NSFont(name: "Helvetica-Bold", size: 18) ?? NSFont.systemFont(ofSize: 18, weight: .bold)
+    static let fontTitle = NSFont(name: "Helvetica-Bold", size: 20) ?? NSFont.systemFont(ofSize: 20, weight: .bold)
+    /// Libellé discret (type de document, libellés de dates) — gris, petites capitales via .uppercased()
+    static let fontLabel = NSFont(name: "Helvetica", size: 8.5) ?? NSFont.systemFont(ofSize: 8.5)
     static let fontBody = NSFont(name: "Helvetica", size: 10) ?? NSFont.systemFont(ofSize: 10)
     static let fontBodyBold = NSFont(name: "Helvetica-Bold", size: 10) ?? NSFont.systemFont(ofSize: 10, weight: .bold)
     static let fontBodyItalic = NSFont(name: "Helvetica-Oblique", size: 10) ?? NSFont.systemFont(ofSize: 10)
@@ -39,7 +41,7 @@ struct PDFLayout {
     static let fontSmall = NSFont(name: "Helvetica", size: 9) ?? NSFont.systemFont(ofSize: 9)
     static let fontSmallBold = NSFont(name: "Helvetica-Bold", size: 9) ?? NSFont.systemFont(ofSize: 9, weight: .bold)
     static let fontTableHeader = NSFont(name: "Helvetica-Bold", size: 9) ?? NSFont.systemFont(ofSize: 9, weight: .bold)
-    static let fontTotalTTC = NSFont(name: "Helvetica-BoldOblique", size: 12) ?? NSFont.systemFont(ofSize: 12, weight: .bold)
+    static let fontTotalTTC = NSFont(name: "Helvetica-Bold", size: 13) ?? NSFont.systemFont(ofSize: 13, weight: .bold)
     static let fontSection = NSFont(name: "Helvetica-Bold", size: 10) ?? NSFont.systemFont(ofSize: 10, weight: .semibold)
     static let fontClient = NSFont(name: "Helvetica-Bold", size: 11) ?? NSFont.systemFont(ofSize: 11, weight: .bold)
 


### PR DESCRIPTION
## Contexte

PR7 du chantier UI/UX (plan validé) — indépendante des autres PRs, branchée sur `main`. Refresh sobre de la facture PDF, identité olive conservée, pagination intacte.

## Changements

**`PDFLayout`** : titre 18→20 pt ; nouveau `fontLabel` 8,5 pt (libellés discrets) ; total TTC en **Helvetica-Bold 13** (fin du BoldOblique italique daté) ; lignes de tableau 24→26 pt et en-tête 28→30 pt (respiration, offsets de texte recentrés).

**`PDFGenerator`** (4 fonctions, marges A4 / colonnes / `ensurePageSpace` intouchés) :
- Type de document en petites capitales grises au-dessus du numéro (hiérarchie type < numéro).
- Libellés de dates en gris + valeurs en gras (hiérarchie lisible au premier regard).
- **Zébrage** une ligne sur deux avec `themeLight` (l'accent à 7 % — suit la couleur de marque), séparateurs verticaux adoucis (0.3→0.2).
- **Bandeau TTC** : fond thème léger + filet olive supérieur, montant en Bold 13 ; réserve de page des totaux ajustée (85→95).

## Vérification

- `swift build` : 0 erreur, 0 warning.
- `--run-regressions` : **72/72**, dont un **nouveau garde-fou de pagination** (`chore(tests)`) : facture de 60 lignes → PDF valide ≥ 2 pages, facture courte → 1 page (via PDFKit).
- Revue sceptique ciblée passée : pas de chevauchement type/titre (4,5 pt de garde), zébrage sous le texte et dans la bordure, ligne de 26 pt sous le seuil de saut de page (80 pt), bandeau TTC contenu, séparateur « : » des libellés non dupliqué.
- À l'œil avant merge : générer une facture FR et EN (courte + 60 lignes) et comparer avant/après ; vérifier l'impression N&B (zébrage à 7 % reste lisible).