### PR TITLE
impr(ui): responsivité — layouts adaptatifs et fenêtre minimale 960 pt

### DIFF
--- a/Facio/Diagnostics/RegressionSuite.swift
+++ b/Facio/Diagnostics/RegressionSuite.swift
@@ -116,8 +116,42 @@ enum FacioRegressionSuite {
         RegressionCase(name: "attachment import copies file and records metadata", run: attachmentImportCopiesFileAndRecordsMetadata),
         RegressionCase(name: "attachment duplication reports missing source files", run: attachmentDuplicationReportsMissingSourceFiles),
         RegressionCase(name: "attachment urls expose only existing files", run: attachmentURLsExposeOnlyExistingFiles),
-        RegressionCase(name: "pdf generation paginates long invoices", run: pdfGenerationPaginatesLongInvoices)
+        RegressionCase(name: "pdf generation paginates long invoices", run: pdfGenerationPaginatesLongInvoices),
+        RegressionCase(name: "responsive width class maps breakpoints", run: responsiveWidthClassMapsBreakpoints),
+        RegressionCase(name: "window minimum fits split view columns", run: windowMinimumFitsSplitViewColumns),
+        RegressionCase(name: "sheet minimums fit inside minimum window", run: sheetMinimumsFitInsideMinimumWindow)
     ]
+
+    private static func responsiveWidthClassMapsBreakpoints() throws {
+        try expectEqual(FacioWidthClass(width: FacioLayout.breakpointCompact - 1), .compact)
+        try expectEqual(FacioWidthClass(width: FacioLayout.breakpointCompact), .regular)
+        try expectEqual(FacioWidthClass(width: FacioLayout.breakpointWide - 1), .regular)
+        try expectEqual(FacioWidthClass(width: FacioLayout.breakpointWide), .wide)
+    }
+
+    private static func windowMinimumFitsSplitViewColumns() throws {
+        try expect(
+            FacioLayout.sidebarMin + FacioLayout.contentColumnMin + FacioLayout.detailMin <= FacioLayout.windowMinWidth,
+            "sidebar + content + detail minimums must fit in the minimum window width"
+        )
+    }
+
+    private static func sheetMinimumsFitInsideMinimumWindow() throws {
+        try expect(
+            FacioLayout.sheetMinWidth <= FacioLayout.windowMinWidth - 80,
+            "sheet minimum width must fit inside the minimum window"
+        )
+        try expect(
+            FacioLayout.sheetMinHeight <= FacioLayout.windowMinHeight - 80,
+            "sheet minimum height must fit inside the minimum window"
+        )
+        let fixedColumns = LineItemColumns.qty + LineItemColumns.unitPrice + LineItemColumns.vat
+            + LineItemColumns.totalHT + LineItemColumns.actions
+        try expect(
+            FacioLayout.lineItemsCompactBreakpoint > fixedColumns + FacioLayout.fieldMinWidth,
+            "compact breakpoint must trigger before the fixed line columns overflow"
+        )
+    }
 
     private static func pdfGenerationPaginatesLongInvoices() throws {
         let company = try JSONDecoder().decode(CompanyInfo.self, from: Data(#"{"nom":"Facio SAS"}"#.utf8))

--- a/Facio/Localization/L10n+Common.swift
+++ b/Facio/Localization/L10n+Common.swift
@@ -11,6 +11,7 @@ extension L10n {
     static func delete(_ l: AppLanguage) -> String { l == .fr ? "Supprimer" : "Delete" }
     static func cancel(_ l: AppLanguage) -> String { l == .fr ? "Annuler" : "Cancel" }
     static func close(_ l: AppLanguage) -> String { l == .fr ? "Fermer" : "Close" }
+    static func back(_ l: AppLanguage) -> String { l == .fr ? "Retour" : "Back" }
     static func save(_ l: AppLanguage) -> String { l == .fr ? "Enregistrer" : "Save" }
     static func duplicate(_ l: AppLanguage) -> String { l == .fr ? "Dupliquer" : "Duplicate" }
     static func download(_ l: AppLanguage) -> String { l == .fr ? "Télécharger" : "Download" }

--- a/Facio/PDF/PDFPreviewView.swift
+++ b/Facio/PDF/PDFPreviewView.swift
@@ -69,7 +69,10 @@ struct PDFPreviewSheet: View {
                 PDFPreviewView(data: pdfData)
             }
         }
-        .frame(minWidth: 650, minHeight: 850)
+        // Garde-fou minimal ; .page dimensionne la sheet proportionnellement
+        // à la fenêtre (idéal pour un aperçu A4) sans jamais la clipper.
+        .frame(minWidth: FacioLayout.sheetMinWidth, minHeight: 420)
+        .presentationSizing(.page)
         .alert(L10n.pdfGenerationError(lang), isPresented: $showPDFGenerationAlert) {
             Button(L10n.understood(lang), role: .cancel) {}
         } message: {

--- a/Facio/Views/Clients/ClientListView.swift
+++ b/Facio/Views/Clients/ClientListView.swift
@@ -5,6 +5,7 @@ struct ClientListView: View {
     var onSelectDocument: (Document) -> Void = { _ in }
 
     @Environment(DataStore.self) private var dataStore
+    @Environment(\.facioWidthClass) private var widthClass
     @State private var searchText = ""
     @State private var clientPendingDeletion: ClientInfo?
 
@@ -32,44 +33,11 @@ struct ClientListView: View {
     }
 
     var body: some View {
-        HStack(spacing: 0) {
-            List(filteredClients, selection: $selectedClientId) { client in
-                ClientRow(client: client)
-                    .tag(client.id)
-                    .contextMenu {
-                        Button(L10n.delete(lang), role: .destructive) {
-                            clientPendingDeletion = client
-                        }
-                    }
-            }
-            .searchable(text: $searchText, prompt: L10n.searchClientPrompt(lang))
-            .overlay {
-                if filteredClients.isEmpty {
-                    FacioEmptyState(
-                        title: searchText.isEmpty ? L10n.noClientsYet(lang) : L10n.noSearchResults(lang),
-                        systemImage: searchText.isEmpty ? "person.2" : "magnifyingglass",
-                        message: searchText.isEmpty ? L10n.selectOrCreateClient(lang) : L10n.noSearchResultsHint(lang)
-                    )
-                }
-            }
-            .frame(minWidth: 280, idealWidth: 360, maxWidth: 520, maxHeight: .infinity)
-
-            Divider()
-
-            if let client = selectedClient {
-                ClientDetailView(
-                    client: client,
-                    onSelectDocument: onSelectDocument,
-                    onCreateDocument: createDocument
-                )
-                    .frame(minWidth: 420, maxWidth: .infinity, maxHeight: .infinity)
+        Group {
+            if widthClass == .compact {
+                compactLayout
             } else {
-                FacioEmptyState(
-                    title: L10n.noClientSelected(lang),
-                    systemImage: "person.crop.circle",
-                    message: L10n.selectOrCreateClient(lang)
-                )
-                .frame(minWidth: 420, maxWidth: .infinity, maxHeight: .infinity)
+                splitLayout
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -105,6 +73,92 @@ struct ClientListView: View {
                 self.selectedClientId = nil
             }
         }
+    }
+
+    // MARK: - Layouts
+
+    /// Split 2 colonnes maison pour les largeurs regular/wide.
+    private var splitLayout: some View {
+        HStack(spacing: 0) {
+            clientList
+                .frame(minWidth: 260, idealWidth: 340, maxWidth: 480, maxHeight: .infinity)
+
+            Divider()
+
+            detailPane
+                .frame(minWidth: 380, maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    /// Navigation empilée en largeur compacte : le détail pleine largeur
+    /// (précédé d'un bouton retour) quand un client est sélectionné, sinon la liste.
+    @ViewBuilder
+    private var compactLayout: some View {
+        if let client = selectedClient {
+            VStack(alignment: .leading, spacing: 0) {
+                Button {
+                    selectedClientId = nil
+                } label: {
+                    Label(L10n.back(lang), systemImage: "chevron.left")
+                }
+                .buttonStyle(.borderless)
+                .padding(.horizontal, FacioLayout.screenPadding)
+                .padding(.vertical, FacioLayout.space8)
+
+                Divider()
+
+                detailView(for: client)
+            }
+        } else {
+            clientList
+        }
+    }
+
+    /// Liste des clients, partagée entre les variantes split et empilée.
+    private var clientList: some View {
+        List(filteredClients, selection: $selectedClientId) { client in
+            ClientRow(client: client)
+                .tag(client.id)
+                .contextMenu {
+                    Button(L10n.delete(lang), role: .destructive) {
+                        clientPendingDeletion = client
+                    }
+                }
+        }
+        .searchable(text: $searchText, prompt: L10n.searchClientPrompt(lang))
+        .overlay {
+            if filteredClients.isEmpty {
+                FacioEmptyState(
+                    title: searchText.isEmpty ? L10n.noClientsYet(lang) : L10n.noSearchResults(lang),
+                    systemImage: searchText.isEmpty ? "person.2" : "magnifyingglass",
+                    message: searchText.isEmpty ? L10n.selectOrCreateClient(lang) : L10n.noSearchResultsHint(lang)
+                )
+            }
+        }
+    }
+
+    /// Colonne détail du split : détail du client sélectionné ou état vide.
+    @ViewBuilder
+    private var detailPane: some View {
+        if let client = selectedClient {
+            detailView(for: client)
+        } else {
+            FacioEmptyState(
+                title: L10n.noClientSelected(lang),
+                systemImage: "person.crop.circle",
+                message: L10n.selectOrCreateClient(lang)
+            )
+        }
+    }
+
+    /// Détail d'un client, partagé entre les variantes split et empilée.
+    private func detailView(for client: ClientInfo) -> some View {
+        ClientDetailView(
+            client: client,
+            onSelectDocument: onSelectDocument,
+            onCreateDocument: createDocument
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private func createClient() {

--- a/Facio/Views/Components/DesignSystem.swift
+++ b/Facio/Views/Components/DesignSystem.swift
@@ -63,7 +63,7 @@ enum FacioLayout {
     static let contentColumnIdeal: CGFloat = 320
     static let contentColumnMax: CGFloat = 400
 
-    static let detailMin: CGFloat = 560
+    static let detailMin: CGFloat = 460
 
     static let inspectorMin: CGFloat = 260
     static let inspectorIdeal: CGFloat = 300
@@ -75,7 +75,7 @@ enum FacioLayout {
     /// Alias historique de `breakpointWide`.
     static let documentInspectorBreakpoint: CGFloat = breakpointWide
 
-    static let windowMinWidth: CGFloat = 1060
+    static let windowMinWidth: CGFloat = 960
     static let windowMinHeight: CGFloat = 640
     static let windowIdealWidth: CGFloat = 1280
     static let windowIdealHeight: CGFloat = 820

--- a/Facio/Views/Components/DesignSystem.swift
+++ b/Facio/Views/Components/DesignSystem.swift
@@ -72,12 +72,35 @@ enum FacioLayout {
     static let inspectorWidth: CGFloat = 280
 
     /// Largeur en deçà de laquelle l'inspecteur du document est masqué.
-    static let documentInspectorBreakpoint: CGFloat = 1120
+    /// Alias historique de `breakpointWide`.
+    static let documentInspectorBreakpoint: CGFloat = breakpointWide
 
     static let windowMinWidth: CGFloat = 1060
     static let windowMinHeight: CGFloat = 640
     static let windowIdealWidth: CGFloat = 1280
     static let windowIdealHeight: CGFloat = 820
+
+    // MARK: Breakpoints responsive (FacioWidthClass)
+    /// En deçà : layouts compacts (piles verticales, sidebars repliées).
+    static let breakpointCompact: CGFloat = 640
+    /// Au-delà : layouts larges (inspecteur latéral visible).
+    static let breakpointWide: CGFloat = 1120
+    /// Largeur minimale d'un champ dans une `FormGrid`.
+    static let fieldMinWidth: CGFloat = 150
+    /// Largeur de conteneur sous laquelle le tableau de lignes passe en mode compact.
+    static let lineItemsCompactBreakpoint: CGFloat = 700
+    /// Cap de largeur du panneau de totaux (pleine largeur en compact).
+    static let totalsMaxWidth: CGFloat = 350
+
+    // MARK: Sheets (invariant : min ≤ fenêtre min − 80 par dimension)
+    static let sheetMinWidth: CGFloat = 480
+    static let sheetIdealWidth: CGFloat = 600
+    static let sheetMinHeight: CGFloat = 360
+    static let sheetIdealHeight: CGFloat = 520
+
+    // MARK: Sidebar des réglages
+    static let settingsSidebarWidth: CGFloat = 230
+    static let settingsSidebarCompactWidth: CGFloat = 64
 }
 
 // MARK: - Intent / tone

--- a/Facio/Views/Components/ResponsiveLayout.swift
+++ b/Facio/Views/Components/ResponsiveLayout.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+
+/// Classe de largeur d'un conteneur : pilote les bascules de layout
+/// (HStack→VStack, colonnes de grilles, sidebars repliées).
+///
+/// Règles d'usage :
+/// - `ViewThatFits` UNIQUEMENT quand toutes les variantes ont une taille
+///   intrinsèque (Texts, Labels, Pickers, DatePickers) — dès qu'un TextField
+///   est présent (compressible à l'infini), passer par `facioWidthClass` /
+///   `AdaptiveStack` / `FormGrid`.
+/// - Tout conteneur dont la largeur réelle diffère de la colonne détail
+///   (ex : éditeur avec inspecteur latéral) re-pose `.facioResponsiveContainer()`.
+enum FacioWidthClass: Equatable {
+    case compact
+    case regular
+    case wide
+
+    init(width: CGFloat) {
+        if width < FacioLayout.breakpointCompact {
+            self = .compact
+        } else if width >= FacioLayout.breakpointWide {
+            self = .wide
+        } else {
+            self = .regular
+        }
+    }
+}
+
+// EnvironmentKeys manuelles : le macro @Entry exige le plugin SwiftUIMacros,
+// absent des builds SPM en ligne de commande.
+private struct FacioWidthClassKey: EnvironmentKey {
+    static var defaultValue: FacioWidthClass { .regular }
+}
+
+private struct FacioContainerWidthKey: EnvironmentKey {
+    static var defaultValue: CGFloat { FacioLayout.windowIdealWidth }
+}
+
+extension EnvironmentValues {
+    /// Classe de largeur posée par le conteneur responsive le plus proche.
+    var facioWidthClass: FacioWidthClass {
+        get { self[FacioWidthClassKey.self] }
+        set { self[FacioWidthClassKey.self] = newValue }
+    }
+
+    /// Largeur réelle du conteneur responsive le plus proche.
+    var facioContainerWidth: CGFloat {
+        get { self[FacioContainerWidthKey.self] }
+        set { self[FacioContainerWidthKey.self] = newValue }
+    }
+}
+
+/// Mesure la largeur du conteneur et la propage dans l'environnement.
+private struct FacioResponsiveContainer: ViewModifier {
+    @State private var width: CGFloat = FacioLayout.windowIdealWidth
+
+    func body(content: Content) -> some View {
+        content
+            .onGeometryChange(for: CGFloat.self, of: { $0.size.width }) { width = $0 }
+            .environment(\.facioWidthClass, FacioWidthClass(width: width))
+            .environment(\.facioContainerWidth, width)
+    }
+}
+
+extension View {
+    func facioResponsiveContainer() -> some View {
+        modifier(FacioResponsiveContainer())
+    }
+}
+
+/// HStack en largeur confortable, VStack en compact. `AnyLayout` préserve
+/// l'identité des sous-vues : le focus d'un champ survit au changement.
+struct AdaptiveStack<Content: View>: View {
+    var hSpacing: CGFloat = FacioLayout.space12
+    var vSpacing: CGFloat = FacioLayout.space10
+    @ViewBuilder let content: Content
+
+    @Environment(\.facioWidthClass) private var widthClass
+
+    var body: some View {
+        let layout = widthClass == .compact
+            ? AnyLayout(VStackLayout(alignment: .leading, spacing: vSpacing))
+            : AnyLayout(HStackLayout(alignment: .top, spacing: hSpacing))
+        layout { content }
+    }
+}
+
+/// Grille de formulaire adaptative : les champs wrappent naturellement quand
+/// la largeur se réduit. Réservée aux petits groupes (≤ 8 champs) rendus d'un
+/// bloc — LazyVGrid peut décharger l'état local des cellules hors écran.
+struct FormGrid<Content: View>: View {
+    var minimum: CGFloat = FacioLayout.fieldMinWidth
+    var maximum: CGFloat = .infinity
+    var spacing: CGFloat = FacioLayout.space12
+    @ViewBuilder let content: Content
+
+    init(
+        minimum: CGFloat = FacioLayout.fieldMinWidth,
+        maximum: CGFloat = .infinity,
+        spacing: CGFloat = FacioLayout.space12,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.minimum = minimum
+        self.maximum = maximum
+        self.spacing = spacing
+        self.content = content()
+    }
+
+    var body: some View {
+        LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: minimum, maximum: maximum), alignment: .topLeading)],
+            alignment: .leading,
+            spacing: spacing
+        ) {
+            content
+        }
+    }
+}

--- a/Facio/Views/Components/ResponsiveLayout.swift
+++ b/Facio/Views/Components/ResponsiveLayout.swift
@@ -73,6 +73,9 @@ extension View {
 struct AdaptiveStack<Content: View>: View {
     var hSpacing: CGFloat = FacioLayout.space12
     var vSpacing: CGFloat = FacioLayout.space10
+    /// Alignement vertical en mode rangée — `.center` comme les HStack natifs
+    /// que ce conteneur remplace.
+    var hAlignment: VerticalAlignment = .center
     @ViewBuilder let content: Content
 
     @Environment(\.facioWidthClass) private var widthClass
@@ -80,7 +83,7 @@ struct AdaptiveStack<Content: View>: View {
     var body: some View {
         let layout = widthClass == .compact
             ? AnyLayout(VStackLayout(alignment: .leading, spacing: vSpacing))
-            : AnyLayout(HStackLayout(alignment: .top, spacing: hSpacing))
+            : AnyLayout(HStackLayout(alignment: hAlignment, spacing: hSpacing))
         layout { content }
     }
 }

--- a/Facio/Views/ContentView.swift
+++ b/Facio/Views/ContentView.swift
@@ -45,6 +45,7 @@ struct ContentView: View {
                 } detail: {
                     detailForSection
                         .frame(minWidth: FacioLayout.detailMin)
+                        .facioResponsiveContainer()
                 }
             } else {
                 NavigationSplitView {
@@ -52,6 +53,7 @@ struct ContentView: View {
                 } detail: {
                     detailForSection
                         .frame(minWidth: FacioLayout.detailMin)
+                        .facioResponsiveContainer()
                 }
             }
         }
@@ -65,8 +67,8 @@ struct ContentView: View {
                 selectedSettingsTab: $selectedSettingsTab
             )
             .frame(
-                minWidth: 520, idealWidth: 600, maxWidth: 760,
-                minHeight: 440, idealHeight: 560, maxHeight: 720
+                minWidth: FacioLayout.sheetMinWidth, idealWidth: FacioLayout.sheetIdealWidth, maxWidth: 760,
+                minHeight: FacioLayout.sheetMinHeight, idealHeight: FacioLayout.sheetIdealHeight, maxHeight: 720
             )
         }
         .toolbar {

--- a/Facio/Views/Documents/AddSignatureSheet.swift
+++ b/Facio/Views/Documents/AddSignatureSheet.swift
@@ -33,7 +33,9 @@ struct AddSignatureSheet: View {
             form
             actions
         }
-        .frame(minWidth: 500, minHeight: 300)
+        // Garde-fou minimal ; .form laisse la sheet suivre la taille de la fenêtre.
+        .frame(minWidth: FacioLayout.sheetMinWidth, minHeight: 300)
+        .presentationSizing(.form)
         .onAppear {
             selectedBlockchain = document.blockchain ?? compatibleBlockchains.first ?? .solana
             montant = document.totalTTC

--- a/Facio/Views/Documents/ClientPickerSheet.swift
+++ b/Facio/Views/Documents/ClientPickerSheet.swift
@@ -42,7 +42,11 @@ struct ClientPickerSheet: View {
             newClientForm
             clientList
         }
-        .frame(minWidth: 450, minHeight: 400)
+        .frame(
+            minWidth: FacioLayout.sheetMinWidth,
+            minHeight: FacioLayout.sheetMinHeight,
+            idealHeight: FacioLayout.sheetIdealHeight
+        )
     }
 
     private var toolbar: some View {
@@ -70,10 +74,10 @@ struct ClientPickerSheet: View {
                         .facioField()
                     TextField(L10n.address(lang), text: $newAdresse)
                         .facioField()
-                    HStack {
+                    // Wrap automatique en largeur réduite (code postal + ville).
+                    FormGrid(minimum: 120) {
                         TextField(L10n.postalCode(lang), text: $newCodePostal)
                             .facioField()
-                            .frame(maxWidth: 120)
                         TextField(L10n.city(lang), text: $newVille)
                             .facioField()
                     }

--- a/Facio/Views/Documents/DocumentEditorView.swift
+++ b/Facio/Views/Documents/DocumentEditorView.swift
@@ -69,8 +69,12 @@ struct DocumentEditorView: View {
             let usesSideInspector = geometry.size.width >= FacioLayout.documentInspectorBreakpoint
 
             HStack(spacing: 0) {
+                // Re-pose le conteneur responsive : quand l'inspecteur latéral est
+                // visible, la largeur réelle de la colonne de contenu est plus
+                // étroite que la colonne détail mesurée par ContentView.
                 documentMainScroll(showInlineInspector: !usesSideInspector)
                     .frame(maxWidth: .infinity)
+                    .facioResponsiveContainer()
 
                 if usesSideInspector && hasReadinessIssues {
                     Divider()
@@ -401,32 +405,24 @@ struct DocumentEditorView: View {
     private var enTeteSection: some View {
         VStack(alignment: .leading, spacing: FacioLayout.space12) {
             subsectionHeader(L10n.headerSection(lang))
-            HStack(spacing: FacioLayout.space16) {
-                VStack(alignment: .leading, spacing: FacioLayout.space4) {
-                    Text(L10n.type(lang))
-                        .font(FacioFont.fieldLabel)
-                        .foregroundStyle(.secondary)
+            // Grille adaptative : 4 colonnes en large, wrap auto 4→2→1 en se
+            // réduisant. La grille égalise les largeurs, plus de frames figées.
+            FormGrid(minimum: 140, maximum: 250) {
+                LabeledField(L10n.type(lang)) {
                     Text(document.type.label(for: lang))
                         .font(.headline)
                         .foregroundStyle(Color.appPrimary(from: dataStore.companyInfo))
                 }
 
-                VStack(alignment: .leading, spacing: FacioLayout.space4) {
-                    Text(L10n.number(lang))
-                        .font(FacioFont.fieldLabel)
-                        .foregroundStyle(.secondary)
+                LabeledField(L10n.number(lang)) {
                     TextField(L10n.number(lang), text: Binding(
                         get: { document.number },
                         set: { document.number = $0; scheduleSave() }
                     ))
                     .facioField()
-                    .frame(maxWidth: 250)
                 }
 
-                VStack(alignment: .leading, spacing: FacioLayout.space4) {
-                    Text(L10n.language(lang))
-                        .font(FacioFont.fieldLabel)
-                        .foregroundStyle(.secondary)
+                LabeledField(L10n.language(lang)) {
                     Picker("", selection: Binding(
                         get: { document.langue },
                         set: { newLang in
@@ -439,15 +435,10 @@ struct DocumentEditorView: View {
                         }
                     }
                     .labelsHidden()
-                    .frame(maxWidth: 120)
+                    .frame(maxWidth: .infinity)
                 }
 
-                Spacer()
-
-                VStack(alignment: .leading, spacing: FacioLayout.space4) {
-                    Text(L10n.status(lang))
-                        .font(FacioFont.fieldLabel)
-                        .foregroundStyle(.secondary)
+                LabeledField(L10n.status(lang)) {
                     Picker(L10n.status(lang), selection: Binding(
                         get: { document.status },
                         set: { newStatus in
@@ -474,7 +465,7 @@ struct DocumentEditorView: View {
                         }
                     }
                     .labelsHidden()
-                    .frame(maxWidth: 160)
+                    .frame(maxWidth: .infinity)
                 }
             }
         }
@@ -555,19 +546,15 @@ struct DocumentEditorView: View {
         if document.type == .facture && document.needsAccountingConversion(referenceCurrency: referenceCurrency) {
             VStack(alignment: .leading, spacing: FacioLayout.space12) {
                 subsectionHeader(L10n.accountingConversion(lang))
-                HStack(spacing: FacioLayout.space24) {
-                    VStack(alignment: .leading, spacing: FacioLayout.space4) {
-                        Text(L10n.accountingCurrency(lang))
-                            .font(FacioFont.fieldLabel)
-                            .foregroundStyle(.secondary)
+                // AdaptiveStack (pas ViewThatFits) : le DecimalField est
+                // compressible à l'infini. Empile verticalement en compact.
+                AdaptiveStack(hSpacing: FacioLayout.space24) {
+                    LabeledField(L10n.accountingCurrency(lang)) {
                         Text(referenceCurrency.label)
                             .font(.headline)
                     }
 
-                    VStack(alignment: .leading, spacing: FacioLayout.space4) {
-                        Text(L10n.exchangeRate(lang))
-                            .font(FacioFont.fieldLabel)
-                            .foregroundStyle(.secondary)
+                    LabeledField(L10n.exchangeRate(lang)) {
                         HStack(spacing: FacioLayout.space8) {
                             Text(L10n.exchangeRatePrefix(lang, source: document.currency.label))
                                 .foregroundStyle(.secondary)
@@ -601,16 +588,11 @@ struct DocumentEditorView: View {
                     }
 
                     if let total = document.accountingTotal(referenceCurrency: referenceCurrency) {
-                        VStack(alignment: .leading, spacing: FacioLayout.space4) {
-                            Text(L10n.accountingTotal(lang))
-                                .font(FacioFont.fieldLabel)
-                                .foregroundStyle(.secondary)
+                        LabeledField(L10n.accountingTotal(lang)) {
                             Text(referenceCurrency.formatAccounting(total, lang: dataStore.companyInfo.formatNombre))
                                 .font(.headline.monospacedDigit())
                         }
                     }
-
-                    Spacer()
                 }
 
                 if document.accountingTotal(referenceCurrency: referenceCurrency) == nil {
@@ -646,10 +628,8 @@ struct DocumentEditorView: View {
 
     private var clientFields: some View {
         VStack(alignment: .leading, spacing: FacioLayout.space12) {
-            VStack(alignment: .leading, spacing: FacioLayout.space4) {
-                Text(L10n.name(lang))
-                    .font(FacioFont.fieldLabel)
-                    .foregroundStyle(.secondary)
+            // Nom et adresse restent pleine largeur, hors grille.
+            LabeledField(L10n.name(lang)) {
                 TextField(L10n.clientName(lang), text: Binding(
                     get: { document.clientNom },
                     set: { document.clientNom = $0; scheduleSave() }
@@ -657,10 +637,7 @@ struct DocumentEditorView: View {
                 .facioField()
             }
 
-            VStack(alignment: .leading, spacing: FacioLayout.space4) {
-                Text(L10n.address(lang))
-                    .font(FacioFont.fieldLabel)
-                    .foregroundStyle(.secondary)
+            LabeledField(L10n.address(lang)) {
                 TextField(L10n.address(lang), text: Binding(
                     get: { document.clientAdresse },
                     set: { document.clientAdresse = $0; scheduleSave() }
@@ -668,36 +645,26 @@ struct DocumentEditorView: View {
                 .facioField()
             }
 
-            HStack(spacing: FacioLayout.space16) {
-                VStack(alignment: .leading, spacing: FacioLayout.space4) {
-                    Text(L10n.postalCode(lang))
-                        .font(FacioFont.fieldLabel)
-                        .foregroundStyle(.secondary)
+            // Les 5 petits champs wrappent en grille : 5→3→2→1 colonnes
+            // selon la largeur disponible.
+            FormGrid(minimum: 150, maximum: 280) {
+                LabeledField(L10n.postalCode(lang)) {
                     TextField(L10n.postalCode(lang), text: Binding(
                         get: { document.clientCodePostal },
                         set: { document.clientCodePostal = $0; scheduleSave() }
                     ))
                     .facioField()
-                    .frame(maxWidth: 120)
                 }
 
-                VStack(alignment: .leading, spacing: FacioLayout.space4) {
-                    Text(L10n.city(lang))
-                        .font(FacioFont.fieldLabel)
-                        .foregroundStyle(.secondary)
+                LabeledField(L10n.city(lang)) {
                     TextField(L10n.city(lang), text: Binding(
                         get: { document.clientVille },
                         set: { document.clientVille = $0; scheduleSave() }
                     ))
                     .facioField()
                 }
-            }
 
-            HStack(spacing: FacioLayout.space16) {
-                VStack(alignment: .leading, spacing: FacioLayout.space4) {
-                    Text(L10n.siret(lang))
-                        .font(FacioFont.fieldLabel)
-                        .foregroundStyle(.secondary)
+                LabeledField(L10n.siret(lang)) {
                     TextField(L10n.siret(lang), text: Binding(
                         get: { document.clientSiret },
                         set: { document.clientSiret = $0; scheduleSave() }
@@ -705,10 +672,7 @@ struct DocumentEditorView: View {
                     .facioField()
                 }
 
-                VStack(alignment: .leading, spacing: FacioLayout.space4) {
-                    Text(L10n.vatNumber(lang))
-                        .font(FacioFont.fieldLabel)
-                        .foregroundStyle(.secondary)
+                LabeledField(L10n.vatNumber(lang)) {
                     TextField(L10n.vatNumber(lang), text: Binding(
                         get: { document.clientTva },
                         set: { document.clientTva = $0; scheduleSave() }
@@ -716,10 +680,7 @@ struct DocumentEditorView: View {
                     .facioField()
                 }
 
-                VStack(alignment: .leading, spacing: FacioLayout.space4) {
-                    Text(L10n.apeCode(lang))
-                        .font(FacioFont.fieldLabel)
-                        .foregroundStyle(.secondary)
+                LabeledField(L10n.apeCode(lang)) {
                     TextField(L10n.apeCode(lang), text: Binding(
                         get: { document.clientApe },
                         set: { document.clientApe = $0; scheduleSave() }

--- a/Facio/Views/Documents/DocumentLineItemsSection.swift
+++ b/Facio/Views/Documents/DocumentLineItemsSection.swift
@@ -8,6 +8,13 @@ enum LineItemColumns {
     static let vat: CGFloat = 80
     static let totalHT: CGFloat = 110
     static let actions: CGFloat = 32
+
+    // Variante compacte (ligne sur deux niveaux, sous
+    // `FacioLayout.lineItemsCompactBreakpoint`) : champs resserrés,
+    // le total prend la place restante en fin de rangée.
+    static let compactQty: CGFloat = 64
+    static let compactUnitPrice: CGFloat = 100
+    static let compactVat: CGFloat = 76
 }
 
 struct DocumentLineItemsSection: View {
@@ -16,11 +23,20 @@ struct DocumentLineItemsSection: View {
     let lang: AppLanguage
     let onSave: () -> Void
 
+    @Environment(\.facioContainerWidth) private var containerWidth
+
+    /// Bascule en disposition compacte (ligne sur deux niveaux) quand la largeur
+    /// ne permet plus les colonnes fixes + une désignation lisible (≈ 620 pt).
+    private var compact: Bool { containerWidth < FacioLayout.lineItemsCompactBreakpoint }
+
     var body: some View {
         SectionPanel(L10n.linesSection(lang), systemImage: "list.bullet.rectangle") {
             VStack(alignment: .leading, spacing: FacioLayout.space8) {
-                header
-                Divider()
+                // En compact, l'en-tête de colonnes n'a plus de colonnes à titrer.
+                if !compact {
+                    header
+                    Divider()
+                }
                 content
                 Divider()
                 addLineButton
@@ -53,6 +69,7 @@ struct DocumentLineItemsSection: View {
                 LineItemRowView(
                     document: document,
                     ligneId: ligne.id,
+                    compact: compact,
                     onDelete: {
                         document.supprimerLigne(ligne)
                         onSave()

--- a/Facio/Views/Documents/LineItemRowView.swift
+++ b/Facio/Views/Documents/LineItemRowView.swift
@@ -208,6 +208,17 @@ struct DecimalField: View {
             .onAppear {
                 text = value == 0 ? "" : formatDecimal(value)
             }
+            // Commit à chaque frappe (sans reformater) : si la vue est détruite
+            // pendant la saisie (bascule compact/large au franchissement du
+            // breakpoint), aucune saisie n'est perdue.
+            .onChange(of: text) {
+                let cleaned = text.replacingOccurrences(of: ",", with: ".").trimmingCharacters(in: .whitespaces)
+                if let parsed = Decimal(string: cleaned) {
+                    value = parsed
+                } else if cleaned.isEmpty {
+                    value = 0
+                }
+            }
             .onChange(of: isFocused) {
                 if !isFocused {
                     let cleaned = text.replacingOccurrences(of: ",", with: ".").trimmingCharacters(in: .whitespaces)

--- a/Facio/Views/Documents/LineItemRowView.swift
+++ b/Facio/Views/Documents/LineItemRowView.swift
@@ -3,6 +3,9 @@ import SwiftUI
 struct LineItemRowView: View {
     var document: Document
     let ligneId: UUID
+    /// Disposition compacte sur deux niveaux (désignation + actions, puis
+    /// qty/prix/TVA/total) — pilotée par `DocumentLineItemsSection`.
+    var compact: Bool = false
     var onDelete: () -> Void
     var onDuplicate: () -> Void
     var onInsertBelow: () -> Void
@@ -27,96 +30,155 @@ struct LineItemRowView: View {
 
     var body: some View {
         if let currentLigne = ligne {
-            HStack(spacing: FacioLayout.space8) {
-                // Designation
-                TextField(L10n.designationLabel(lang), text: Binding(
-                    get: { document.lignes.first(where: { $0.id == ligneId })?.designation ?? "" },
-                    set: { newVal in
-                        if let i = safeIndex() { document.lignes[i].designation = newVal; onUpdate() }
-                    }
-                ))
-                .facioField(density: .compact)
-                .frame(maxWidth: .infinity)
-
-                // Quantite
-                DecimalField(
-                    placeholder: L10n.qtyShort(lang),
-                    value: Binding(
-                        get: { document.lignes.first(where: { $0.id == ligneId })?.quantite ?? 0 },
-                        set: { newVal in
-                            if let i = safeIndex() { document.lignes[i].quantite = newVal; onUpdate() }
-                        }
-                    )
-                )
-                .format(numberFormat)
-                .frame(width: LineItemColumns.qty)
-
-                // Prix unitaire
-                DecimalField(
-                    placeholder: L10n.priceLabel(lang),
-                    value: Binding(
-                        get: { document.lignes.first(where: { $0.id == ligneId })?.prixUnitaire ?? 0 },
-                        set: { newVal in
-                            if let i = safeIndex() { document.lignes[i].prixUnitaire = newVal; onUpdate() }
-                        }
-                    ),
-                    maximumFractionDigits: document.currency.maximumFractionDigits
-                )
-                .format(numberFormat)
-                .frame(width: LineItemColumns.unitPrice)
-
-                // TVA
-                Picker(L10n.vatLabel(lang), selection: Binding(
-                    get: { document.lignes.first(where: { $0.id == ligneId })?.tauxTVA ?? 0 },
-                    set: { newVal in
-                        if let i = safeIndex() { document.lignes[i].tauxTVA = newVal; onUpdate() }
-                    }
-                )) {
-                    ForEach(Self.tvaRates, id: \.self) { rate in
-                        Text(L10n.vatRateLabel(numberFormat, rate: rate)).tag(rate)
-                    }
+            // Le if/else ne duplique que la STRUCTURE : les champs eux-mêmes
+            // sont des sous-vues privées partagées entre les deux variantes.
+            Group {
+                if compact {
+                    compactRow(for: currentLigne)
+                } else {
+                    regularRow(for: currentLigne)
                 }
-                .labelsHidden()
-                .frame(width: LineItemColumns.vat)
-
-                // Total (lecture seule)
-                Text(document.currency.formatAccounting(currentLigne.totalLigne, lang: numberFormat))
-                    .font(FacioFont.amount)
-                    .frame(width: LineItemColumns.totalHT, alignment: .trailing)
-
-                Menu {
-                    Button {
-                        onInsertBelow()
-                    } label: {
-                        Label(L10n.insertLineBelow(lang), systemImage: "plus")
-                    }
-
-                    Button {
-                        onDuplicate()
-                    } label: {
-                        Label(L10n.duplicateLine(lang), systemImage: "doc.on.doc")
-                    }
-
-                    Divider()
-
-                    Button(role: .destructive) {
-                        onDelete()
-                    } label: {
-                        Label(L10n.deleteLine(lang), systemImage: "trash")
-                    }
-                } label: {
-                    Image(systemName: "ellipsis.circle")
-                        .frame(width: LineItemColumns.actions, height: FacioLayout.iconHitTarget)
-                        .contentShape(Rectangle())
-                }
-                .menuStyle(.borderlessButton)
-                .help(L10n.businessActions(lang))
             }
             .padding(.vertical, FacioLayout.space2)
             .padding(.horizontal, FacioLayout.space4)
             .background(rowNeedsAttention(currentLigne) ? Color.intentWarning.opacity(0.08) : Color.clear)
             .clipShape(RoundedRectangle(cornerRadius: FacioLayout.radiusField))
         }
+    }
+
+    // MARK: - Variantes de disposition
+
+    /// Variante régulière : une seule rangée, colonnes fixes alignées sur
+    /// l'en-tête de `DocumentLineItemsSection`.
+    private func regularRow(for currentLigne: LineItem) -> some View {
+        HStack(spacing: FacioLayout.space8) {
+            designationField
+            qtyField
+                .frame(width: LineItemColumns.qty)
+            priceField
+                .frame(width: LineItemColumns.unitPrice)
+            vatPicker
+                .frame(width: LineItemColumns.vat)
+            totalText(for: currentLigne)
+                .frame(width: LineItemColumns.totalHT, alignment: .trailing)
+            actionsMenu
+        }
+    }
+
+    /// Variante compacte : deux niveaux — désignation + actions, puis
+    /// quantité / prix / TVA et total calé à droite.
+    private func compactRow(for currentLigne: LineItem) -> some View {
+        VStack(alignment: .leading, spacing: FacioLayout.space4) {
+            HStack(spacing: FacioLayout.space8) {
+                designationField
+                actionsMenu
+            }
+            HStack(spacing: FacioLayout.space8) {
+                qtyField
+                    .frame(width: LineItemColumns.compactQty)
+                priceField
+                    .frame(width: LineItemColumns.compactUnitPrice)
+                vatPicker
+                    .frame(width: LineItemColumns.compactVat)
+                Spacer()
+                totalText(for: currentLigne)
+            }
+        }
+    }
+
+    // MARK: - Champs partagés entre les deux variantes
+
+    /// Designation
+    private var designationField: some View {
+        TextField(L10n.designationLabel(lang), text: Binding(
+            get: { document.lignes.first(where: { $0.id == ligneId })?.designation ?? "" },
+            set: { newVal in
+                if let i = safeIndex() { document.lignes[i].designation = newVal; onUpdate() }
+            }
+        ))
+        .facioField(density: .compact)
+        .frame(maxWidth: .infinity)
+    }
+
+    /// Quantite
+    private var qtyField: some View {
+        DecimalField(
+            placeholder: L10n.qtyShort(lang),
+            value: Binding(
+                get: { document.lignes.first(where: { $0.id == ligneId })?.quantite ?? 0 },
+                set: { newVal in
+                    if let i = safeIndex() { document.lignes[i].quantite = newVal; onUpdate() }
+                }
+            )
+        )
+        .format(numberFormat)
+    }
+
+    /// Prix unitaire
+    private var priceField: some View {
+        DecimalField(
+            placeholder: L10n.priceLabel(lang),
+            value: Binding(
+                get: { document.lignes.first(where: { $0.id == ligneId })?.prixUnitaire ?? 0 },
+                set: { newVal in
+                    if let i = safeIndex() { document.lignes[i].prixUnitaire = newVal; onUpdate() }
+                }
+            ),
+            maximumFractionDigits: document.currency.maximumFractionDigits
+        )
+        .format(numberFormat)
+    }
+
+    /// TVA
+    private var vatPicker: some View {
+        Picker(L10n.vatLabel(lang), selection: Binding(
+            get: { document.lignes.first(where: { $0.id == ligneId })?.tauxTVA ?? 0 },
+            set: { newVal in
+                if let i = safeIndex() { document.lignes[i].tauxTVA = newVal; onUpdate() }
+            }
+        )) {
+            ForEach(Self.tvaRates, id: \.self) { rate in
+                Text(L10n.vatRateLabel(numberFormat, rate: rate)).tag(rate)
+            }
+        }
+        .labelsHidden()
+    }
+
+    /// Total (lecture seule)
+    private func totalText(for line: LineItem) -> some View {
+        Text(document.currency.formatAccounting(line.totalLigne, lang: numberFormat))
+            .font(FacioFont.amount)
+    }
+
+    /// Menu d'actions de la ligne (insérer / dupliquer / supprimer)
+    private var actionsMenu: some View {
+        Menu {
+            Button {
+                onInsertBelow()
+            } label: {
+                Label(L10n.insertLineBelow(lang), systemImage: "plus")
+            }
+
+            Button {
+                onDuplicate()
+            } label: {
+                Label(L10n.duplicateLine(lang), systemImage: "doc.on.doc")
+            }
+
+            Divider()
+
+            Button(role: .destructive) {
+                onDelete()
+            } label: {
+                Label(L10n.deleteLine(lang), systemImage: "trash")
+            }
+        } label: {
+            Image(systemName: "ellipsis.circle")
+                .frame(width: LineItemColumns.actions, height: FacioLayout.iconHitTarget)
+                .contentShape(Rectangle())
+        }
+        .menuStyle(.borderlessButton)
+        .help(L10n.businessActions(lang))
     }
 
     private func rowNeedsAttention(_ line: LineItem) -> Bool {

--- a/Facio/Views/Documents/TotalsView.swift
+++ b/Facio/Views/Documents/TotalsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct TotalsView: View {
     let document: Document
     @Environment(DataStore.self) private var dataStore
+    @Environment(\.facioWidthClass) private var widthClass
 
     private var lang: AppLanguage { dataStore.companyInfo.langueParDefaut }
     private var numberFormat: AppLanguage { dataStore.companyInfo.formatNombre }
@@ -52,7 +53,8 @@ struct TotalsView: View {
                     }
                 }
             }
-            .frame(maxWidth: 350)
+            // Pleine largeur en compact, sinon panneau aligné à droite.
+            .frame(maxWidth: widthClass == .compact ? .infinity : FacioLayout.totalsMaxWidth)
         }
     }
 

--- a/Facio/Views/Settings/SettingsInlineView.swift
+++ b/Facio/Views/Settings/SettingsInlineView.swift
@@ -29,26 +29,11 @@ struct SettingsInlineView: View {
 
     var body: some View {
         HStack(spacing: 0) {
-            VStack(alignment: .leading, spacing: 16) {
-                Text(L10n.settings(lang))
-                    .font(.title2)
-                    .fontWeight(.bold)
-                    .padding(.horizontal, 16)
-                    .padding(.top, 18)
-
-                List(selection: Binding<Int?>(
-                    get: { selectedTab },
-                    set: { selectedTab = $0 ?? selectedTab }
-                )) {
-                    ForEach(Array(tabs.enumerated()), id: \.offset) { index, tab in
-                        Label(tab.label, systemImage: tab.icon)
-                            .tag(index)
-                    }
-                }
-                .listStyle(.sidebar)
-            }
-            .frame(width: 230)
-            .background(Color(nsColor: .controlBackgroundColor))
+            SettingsSidebarColumn(
+                title: L10n.settings(lang),
+                tabs: tabs,
+                selectedTab: $selectedTab
+            )
 
             Divider()
 
@@ -57,15 +42,19 @@ struct SettingsInlineView: View {
                     settingsHeader
                     selectedSettingsView
                 }
-                .frame(maxWidth: 760, alignment: .topLeading)
+                .frame(maxWidth: FacioLayout.contentMaxWidth, alignment: .topLeading)
                 .frame(maxWidth: .infinity, alignment: .top)
             }
         }
-        .frame(minWidth: 700, maxWidth: .infinity, maxHeight: .infinity)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        // Seul écran avec sa propre sidebar interne : on re-pose le conteneur
+        // responsive sur le HStack racine (indispensable aussi pour la scène
+        // Réglages native, qui n'hérite pas du conteneur de ContentView).
+        .facioResponsiveContainer()
     }
 
     private var settingsHeader: some View {
-        VStack(alignment: .leading, spacing: 6) {
+        VStack(alignment: .leading, spacing: FacioLayout.space6) {
             Label(selectedTabInfo.label, systemImage: selectedTabInfo.icon)
                 .font(FacioFont.screenTitle)
             Text(selectedTabInfo.help)
@@ -73,9 +62,9 @@ struct SettingsInlineView: View {
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
         }
-        .padding(.horizontal, 24)
-        .padding(.top, 24)
-        .padding(.bottom, 4)
+        .padding(.horizontal, FacioLayout.space24)
+        .padding(.top, FacioLayout.space24)
+        .padding(.bottom, FacioLayout.space4)
     }
 
     @ViewBuilder
@@ -91,6 +80,59 @@ struct SettingsInlineView: View {
         case 7: SyncSettingsView(syncService: syncService, authService: authService)
         case 8: AboutSettingsView()
         default: EmptyView()
+        }
+    }
+}
+
+/// Sidebar interne des réglages : repliée en icônes seules sous le breakpoint
+/// compact. Sous-vue séparée pour lire la classe de largeur RE-posée par le
+/// conteneur responsive du HStack racine (un `@Environment` lu directement
+/// dans `SettingsInlineView` verrait celui du parent).
+private struct SettingsSidebarColumn: View {
+    let title: String
+    let tabs: [(label: String, icon: String, help: String)]
+    @Binding var selectedTab: Int
+
+    @Environment(\.facioWidthClass) private var widthClass
+
+    private var isCompact: Bool { widthClass == .compact }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: FacioLayout.space16) {
+            // En compact, le titre de colonne est masqué (la sidebar réduite
+            // aux icônes ne peut pas l'afficher).
+            if !isCompact {
+                Text(title)
+                    .font(.title2)
+                    .fontWeight(.bold)
+                    .padding(.horizontal, FacioLayout.space16)
+                    .padding(.top, FacioLayout.space16)
+            }
+
+            List(selection: Binding<Int?>(
+                get: { selectedTab },
+                set: { selectedTab = $0 ?? selectedTab }
+            )) {
+                ForEach(Array(tabs.enumerated()), id: \.offset) { index, tab in
+                    tabLabel(tab)
+                        .tag(index)
+                }
+            }
+            .listStyle(.sidebar)
+        }
+        .frame(width: isCompact ? FacioLayout.settingsSidebarCompactWidth : FacioLayout.settingsSidebarWidth)
+        .background(Color(nsColor: .controlBackgroundColor))
+    }
+
+    /// Libellé d'un onglet : icône seule + infobulle (libellé existant) en compact.
+    @ViewBuilder
+    private func tabLabel(_ tab: (label: String, icon: String, help: String)) -> some View {
+        if isCompact {
+            Label(tab.label, systemImage: tab.icon)
+                .labelStyle(.iconOnly)
+                .help(tab.label)
+        } else {
+            Label(tab.label, systemImage: tab.icon)
         }
     }
 }

--- a/Facio/Views/TimeHub/TimeHubView.swift
+++ b/Facio/Views/TimeHub/TimeHubView.swift
@@ -90,69 +90,35 @@ struct TimeHubView: View {
     private func header(interval: DateInterval) -> some View {
         SectionPanel(nil) {
             VStack(alignment: .leading, spacing: FacioLayout.space16) {
-                HStack(alignment: .center, spacing: FacioLayout.space12) {
-                    VStack(alignment: .leading, spacing: FacioLayout.space2) {
-                        Label(L10n.sidebarPlanning(lang), systemImage: "calendar.badge.clock")
-                            .font(FacioFont.screenTitle)
-                        Text(periodTitle(interval))
-                            .font(FacioFont.screenSubtitle)
-                            .foregroundStyle(.secondary)
+                // Rangée titre + contrôles de période : contenu 100 % intrinsèque,
+                // ViewThatFits bascule sur la variante empilée quand la largeur manque.
+                ViewThatFits(in: .horizontal) {
+                    HStack(alignment: .center, spacing: FacioLayout.space12) {
+                        headerTitle(interval: interval)
+                        Spacer()
+                        periodControls
                     }
 
-                    Spacer()
-
-                    Picker("", selection: $periodMode) {
-                        Text(L10n.periodDay(lang)).tag(TimeHubPeriodMode.day)
-                        Text(L10n.periodWeek(lang)).tag(TimeHubPeriodMode.week)
-                        Text(L10n.periodMonth(lang)).tag(TimeHubPeriodMode.month)
-                    }
-                    .labelsHidden()
-                    .pickerStyle(.segmented)
-                    .frame(width: 260)
-
-                    Button {
-                        anchorDate = periodMode.shiftedAnchor(from: anchorDate, value: -1)
-                    } label: {
-                        Image(systemName: "chevron.left")
-                    }
-                    .help(L10n.previousPeriod(lang))
-
-                    Button(L10n.today(lang)) {
-                        anchorDate = Date()
-                    }
-
-                    Button {
-                        anchorDate = periodMode.shiftedAnchor(from: anchorDate, value: 1)
-                    } label: {
-                        Image(systemName: "chevron.right")
-                    }
-                    .help(L10n.nextPeriod(lang))
-                }
-
-                HStack(spacing: FacioLayout.space10) {
-                    Picker(L10n.sidebarClients(lang), selection: $filters.clientId) {
-                        Text(L10n.allClients(lang)).tag(Optional<UUID>.none)
-                        ForEach(dataStore.clients.sorted { $0.displayName < $1.displayName }) { client in
-                            Text(client.displayName.isEmpty ? L10n.noClient(lang) : client.displayName)
-                                .tag(Optional(client.id))
+                    VStack(alignment: .leading, spacing: FacioLayout.space10) {
+                        headerTitle(interval: interval)
+                        HStack(spacing: FacioLayout.space12) {
+                            periodModePicker
+                            Spacer()
+                            periodNavigation
                         }
                     }
-                    .frame(width: 180)
+                }
 
-                    Picker(L10n.billable(lang), selection: $filters.billable) {
-                        Text(L10n.allBillableStates(lang)).tag(Optional<Bool>.none)
-                        Text(L10n.billable(lang)).tag(Optional(true))
-                        Text(L10n.nonBillable(lang)).tag(Optional(false))
-                    }
-                    .frame(width: 170)
+                // Filtres : la grille adaptative fait wrapper les pickers sous 640 pt,
+                // sans branche conditionnelle.
+                FormGrid(minimum: 160, maximum: 260, spacing: FacioLayout.space10) {
+                    clientFilterPicker
+                    billableFilterPicker
+                    invoicedFilterPicker
+                }
 
-                    Picker(L10n.invoiced(lang), selection: $filters.invoiced) {
-                        Text(L10n.allInvoiceStates(lang)).tag(Optional<Bool>.none)
-                        Text(L10n.invoiced(lang)).tag(Optional(true))
-                        Text(L10n.notInvoiced(lang)).tag(Optional(false))
-                    }
-                    .frame(width: 170)
-
+                // Recherche + ajout manuel : pleine largeur sous la grille de filtres.
+                HStack(spacing: FacioLayout.space10) {
                     TextField(L10n.searchTimeHub(lang), text: $filters.searchText)
                         .facioField()
 
@@ -163,6 +129,89 @@ struct TimeHubView: View {
                     }
                 }
             }
+        }
+    }
+
+    /// Bloc titre + sous-titre de période, partagé entre les variantes du header.
+    private func headerTitle(interval: DateInterval) -> some View {
+        VStack(alignment: .leading, spacing: FacioLayout.space2) {
+            Label(L10n.sidebarPlanning(lang), systemImage: "calendar.badge.clock")
+                .font(FacioFont.screenTitle)
+            Text(periodTitle(interval))
+                .font(FacioFont.screenSubtitle)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    /// Contrôles de période sur une seule ligne (variante large du header).
+    private var periodControls: some View {
+        HStack(spacing: FacioLayout.space12) {
+            periodModePicker
+            periodNavigation
+        }
+    }
+
+    /// Sélecteur jour / semaine / mois, partagé entre les variantes du header.
+    private var periodModePicker: some View {
+        Picker("", selection: $periodMode) {
+            Text(L10n.periodDay(lang)).tag(TimeHubPeriodMode.day)
+            Text(L10n.periodWeek(lang)).tag(TimeHubPeriodMode.week)
+            Text(L10n.periodMonth(lang)).tag(TimeHubPeriodMode.month)
+        }
+        .labelsHidden()
+        .pickerStyle(.segmented)
+        .frame(width: 260)
+    }
+
+    /// Navigation temporelle précédent / aujourd'hui / suivant, partagée.
+    private var periodNavigation: some View {
+        HStack(spacing: FacioLayout.space12) {
+            Button {
+                anchorDate = periodMode.shiftedAnchor(from: anchorDate, value: -1)
+            } label: {
+                Image(systemName: "chevron.left")
+            }
+            .help(L10n.previousPeriod(lang))
+
+            Button(L10n.today(lang)) {
+                anchorDate = Date()
+            }
+
+            Button {
+                anchorDate = periodMode.shiftedAnchor(from: anchorDate, value: 1)
+            } label: {
+                Image(systemName: "chevron.right")
+            }
+            .help(L10n.nextPeriod(lang))
+        }
+    }
+
+    /// Filtre par client — la largeur est pilotée par la cellule de la FormGrid.
+    private var clientFilterPicker: some View {
+        Picker(L10n.sidebarClients(lang), selection: $filters.clientId) {
+            Text(L10n.allClients(lang)).tag(Optional<UUID>.none)
+            ForEach(dataStore.clients.sorted { $0.displayName < $1.displayName }) { client in
+                Text(client.displayName.isEmpty ? L10n.noClient(lang) : client.displayName)
+                    .tag(Optional(client.id))
+            }
+        }
+    }
+
+    /// Filtre facturable / non facturable.
+    private var billableFilterPicker: some View {
+        Picker(L10n.billable(lang), selection: $filters.billable) {
+            Text(L10n.allBillableStates(lang)).tag(Optional<Bool>.none)
+            Text(L10n.billable(lang)).tag(Optional(true))
+            Text(L10n.nonBillable(lang)).tag(Optional(false))
+        }
+    }
+
+    /// Filtre facturé / non facturé.
+    private var invoicedFilterPicker: some View {
+        Picker(L10n.invoiced(lang), selection: $filters.invoiced) {
+            Text(L10n.allInvoiceStates(lang)).tag(Optional<Bool>.none)
+            Text(L10n.invoiced(lang)).tag(Optional(true))
+            Text(L10n.notInvoiced(lang)).tag(Optional(false))
         }
     }
 

--- a/Facio/Views/TimeHub/TimeHubView.swift
+++ b/Facio/Views/TimeHub/TimeHubView.swift
@@ -1087,7 +1087,7 @@ private struct TimeHubManualEntrySheet: View {
             }
         }
         .padding(FacioLayout.space20)
-        .frame(width: 520)
+        .frame(minWidth: FacioLayout.sheetMinWidth, idealWidth: 520, maxWidth: 560)
         .onAppear {
             selectedTimesheetId = selectedTimesheet?.id
         }

--- a/Facio/Views/Timesheet/TimeTrackerPanel.swift
+++ b/Facio/Views/Timesheet/TimeTrackerPanel.swift
@@ -232,7 +232,8 @@ struct TimeTrackerPanel: View {
 
     private var inputFields: some View {
         VStack(alignment: .leading, spacing: FacioLayout.space10) {
-            HStack(spacing: FacioLayout.space10) {
+            // Les champs wrappent 3→2→1 colonnes selon la largeur disponible
+            FormGrid(minimum: 160, spacing: FacioLayout.space10) {
                 TextField(L10n.timeEntryDescription(lang), text: $notes)
                     .facioField()
                 TextField(L10n.project(lang), text: $projectName)
@@ -240,19 +241,19 @@ struct TimeTrackerPanel: View {
                 TextField(L10n.task(lang), text: $taskName)
                     .facioField()
             }
-            HStack(spacing: FacioLayout.space10) {
+            FormGrid(minimum: 160, spacing: FacioLayout.space10) {
                 TextField(L10n.tags(lang), text: $tagsText)
                     .facioField()
                 Toggle(L10n.billable(lang), isOn: $isBillable)
                     .toggleStyle(.switch)
-                Spacer()
             }
         }
     }
 
     private func entryFields(for entry: TimeEntry) -> some View {
         VStack(alignment: .leading, spacing: FacioLayout.space10) {
-            HStack(spacing: FacioLayout.space10) {
+            // Les champs wrappent 3→2→1 colonnes selon la largeur disponible
+            FormGrid(minimum: 160, spacing: FacioLayout.space10) {
                 TextField(L10n.timeEntryDescription(lang), text: entryStringBinding(entry, \.notes))
                     .facioField()
                 TextField(L10n.project(lang), text: entryStringBinding(entry, \.projectName))
@@ -260,12 +261,11 @@ struct TimeTrackerPanel: View {
                 TextField(L10n.task(lang), text: entryStringBinding(entry, \.taskName))
                     .facioField()
             }
-            HStack(spacing: FacioLayout.space10) {
+            FormGrid(minimum: 160, spacing: FacioLayout.space10) {
                 TextField(L10n.tags(lang), text: entryStringBinding(entry, \.tagsText))
                     .facioField()
                 Toggle(L10n.billable(lang), isOn: entryBoolBinding(entry, \.isBillable))
                     .toggleStyle(.switch)
-                Spacer()
             }
         }
     }
@@ -273,28 +273,35 @@ struct TimeTrackerPanel: View {
     private var manualControls: some View {
         VStack(alignment: .leading, spacing: FacioLayout.space12) {
             inputFields
-            HStack(spacing: FacioLayout.space10) {
-                DatePicker(
-                    L10n.period(lang),
-                    selection: $manualDate,
-                    in: timesheet.activeStartDate...timesheet.activeEndDate,
-                    displayedComponents: [.date]
-                )
-                .labelsHidden()
-                DatePicker(L10n.startDate(lang), selection: $manualStartTime, displayedComponents: [.hourAndMinute])
+            // Deux groupes : une seule ligne en regular, deux lignes en compact
+            AdaptiveStack(hSpacing: FacioLayout.space10, vSpacing: FacioLayout.space10) {
+                // Groupe A : les 3 DatePickers (intrinsèques) restent en ligne même en compact
+                HStack(spacing: FacioLayout.space10) {
+                    DatePicker(
+                        L10n.period(lang),
+                        selection: $manualDate,
+                        in: timesheet.activeStartDate...timesheet.activeEndDate,
+                        displayedComponents: [.date]
+                    )
                     .labelsHidden()
-                DatePicker(L10n.endDate(lang), selection: $manualEndTime, displayedComponents: [.hourAndMinute])
-                    .labelsHidden()
-                TextField(L10n.duration(lang), text: $manualDurationInput)
-                    .facioField()
-                    .frame(width: 110)
-                Button {
-                    addManualEntry()
-                } label: {
-                    Label(L10n.addTimeEntry(lang), systemImage: "plus")
+                    DatePicker(L10n.startDate(lang), selection: $manualStartTime, displayedComponents: [.hourAndMinute])
+                        .labelsHidden()
+                    DatePicker(L10n.endDate(lang), selection: $manualEndTime, displayedComponents: [.hourAndMinute])
+                        .labelsHidden()
                 }
-                .buttonStyle(.facio(.primary))
-                Spacer()
+                // Groupe B : durée + bouton d'ajout
+                HStack(spacing: FacioLayout.space10) {
+                    TextField(L10n.duration(lang), text: $manualDurationInput)
+                        .facioField()
+                        .frame(width: 110)
+                    Button {
+                        addManualEntry()
+                    } label: {
+                        Label(L10n.addTimeEntry(lang), systemImage: "plus")
+                    }
+                    .buttonStyle(.facio(.primary))
+                    Spacer()
+                }
             }
             Text(L10n.durationExamples(lang))
                 .font(FacioFont.caption)
@@ -303,47 +310,54 @@ struct TimeTrackerPanel: View {
     }
 
     private var filterBar: some View {
-        HStack(spacing: FacioLayout.space12) {
-            Picker("", selection: $range) {
-                ForEach(TimeEntryRange.allCases) { range in
-                    Text(range.label(for: lang)).tag(range)
-                }
-            }
-            .labelsHidden()
-            .pickerStyle(.segmented)
-            .frame(width: 260)
-
-            TextField(L10n.searchTimeEntries(lang), text: $searchText)
-                .facioField()
-
-            Button {
-                inputMode = .manual
-            } label: {
-                Label(L10n.newTimeEntry(lang), systemImage: "plus")
-            }
-
-            Button {
-                exportCSV()
-            } label: {
-                Label(L10n.exportCSV(lang), systemImage: "square.and.arrow.down")
-            }
-            .disabled(filteredEntries.isEmpty)
-
-            if let invoice = dataStore.existingBillableHoursInvoice(for: timesheet) {
-                Button {
-                    onOpenInvoice(invoice)
-                } label: {
-                    Label(L10n.openInvoice(lang), systemImage: "doc.text.magnifyingglass")
-                }
-            } else {
-                Button {
-                    if let invoice = dataStore.generateInvoiceFromUnbilledTimeEntries(from: timesheet, grouping: .detailed) {
-                        onOpenInvoice(invoice)
+        // Deux groupes : une seule ligne en regular, deux lignes en compact
+        AdaptiveStack(hSpacing: FacioLayout.space12, vSpacing: FacioLayout.space10) {
+            // Groupe A : filtre de plage + recherche
+            HStack(spacing: FacioLayout.space12) {
+                Picker("", selection: $range) {
+                    ForEach(TimeEntryRange.allCases) { range in
+                        Text(range.label(for: lang)).tag(range)
                     }
-                } label: {
-                    Label(L10n.invoiceTimeEntries(lang), systemImage: "doc.text")
                 }
-                .disabled(!dataStore.canGenerateInvoiceFromTimeEntries(for: timesheet))
+                .labelsHidden()
+                .pickerStyle(.segmented)
+                .frame(width: 260)
+
+                TextField(L10n.searchTimeEntries(lang), text: $searchText)
+                    .facioField()
+            }
+
+            // Groupe B : boutons d'action
+            HStack(spacing: FacioLayout.space12) {
+                Button {
+                    inputMode = .manual
+                } label: {
+                    Label(L10n.newTimeEntry(lang), systemImage: "plus")
+                }
+
+                Button {
+                    exportCSV()
+                } label: {
+                    Label(L10n.exportCSV(lang), systemImage: "square.and.arrow.down")
+                }
+                .disabled(filteredEntries.isEmpty)
+
+                if let invoice = dataStore.existingBillableHoursInvoice(for: timesheet) {
+                    Button {
+                        onOpenInvoice(invoice)
+                    } label: {
+                        Label(L10n.openInvoice(lang), systemImage: "doc.text.magnifyingglass")
+                    }
+                } else {
+                    Button {
+                        if let invoice = dataStore.generateInvoiceFromUnbilledTimeEntries(from: timesheet, grouping: .detailed) {
+                            onOpenInvoice(invoice)
+                        }
+                    } label: {
+                        Label(L10n.invoiceTimeEntries(lang), systemImage: "doc.text")
+                    }
+                    .disabled(!dataStore.canGenerateInvoiceFromTimeEntries(for: timesheet))
+                }
             }
         }
     }

--- a/Facio/Views/Timesheet/TimesheetEditorView.swift
+++ b/Facio/Views/Timesheet/TimesheetEditorView.swift
@@ -5,6 +5,7 @@ struct TimesheetEditorView: View {
     var onOpenInvoice: (Document) -> Void = { _ in }
 
     @Environment(DataStore.self) private var dataStore
+    @Environment(\.facioContainerWidth) private var containerWidth
     @State private var hourInputMode: TimesheetHourInputMode = .decimal
     @State private var showClientPicker = false
     @State private var showInvoiceDetailOptions = false
@@ -16,6 +17,16 @@ struct TimesheetEditorView: View {
     @State private var hourFieldFocusNonce = 0
 
     private var lang: AppLanguage { dataStore.companyInfo.langueParDefaut }
+
+    /// Colonnes de la grille des jours : 7 colonnes égales si la largeur le
+    /// permet (7 × 64 + paddings ≈ 552 pt de conteneur), sinon 4 (rangées 4+3).
+    private var dayGridColumns: [GridItem] {
+        let count = containerWidth < 560 ? 4 : 7
+        return Array(
+            repeating: GridItem(.flexible(minimum: 64), spacing: FacioLayout.space4),
+            count: count
+        )
+    }
     private var numberFormat: AppLanguage { dataStore.companyInfo.formatNombre }
 
     /// Heures des jours hors-mois depuis les périodes adjacentes
@@ -417,9 +428,12 @@ struct TimesheetEditorView: View {
 
                 Divider()
 
-                // Grille des jours : wrap automatique en deux rangées quand la largeur se réduit
+                // Grille des jours : 7 colonnes égales remplissant la largeur en
+                // confortable, 4 colonnes (rangées 4+3) en étroit. Compte fixe
+                // plutôt que .adaptive : l'adaptatif crée des colonnes vides à
+                // droite dès que la largeur dépasse 8 × minimum.
                 LazyVGrid(
-                    columns: [GridItem(.adaptive(minimum: 64, maximum: .infinity), spacing: FacioLayout.space4)],
+                    columns: dayGridColumns,
                     spacing: FacioLayout.space8
                 ) {
                     ForEach(Array(week.jours.enumerated()), id: \.offset) { dayIndex, jour in

--- a/Facio/Views/Timesheet/TimesheetEditorView.swift
+++ b/Facio/Views/Timesheet/TimesheetEditorView.swift
@@ -123,54 +123,72 @@ struct TimesheetEditorView: View {
         let brut = timesheet.totalBrutCrossPeriod(adjacentHours: adj)
         let net = timesheet.totalNetCrossPeriod(adjacentHours: adj)
 
-        let invoiceTone: Color = timesheet.hasGeneratedInvoice ? .intentSuccess : .intentWarning
-
+        // Contenu 100% intrinsèque (Texts uniquement) → ViewThatFits autorisé.
         return SectionPanel {
-            HStack(alignment: .center, spacing: FacioLayout.space16) {
-                VStack(alignment: .leading, spacing: FacioLayout.space6) {
-                    Text(timesheet.periodLabel(for: lang))
-                        .font(FacioFont.heroTitle)
-                    Text(timesheet.clientDisplayName.isEmpty ? L10n.noClient(lang) : timesheet.clientDisplayName)
-                        .font(FacioFont.screenSubtitle)
-                        .foregroundStyle(timesheet.clientDisplayName.isEmpty ? .tertiary : .secondary)
+            ViewThatFits(in: .horizontal) {
+                // Variante large : titre à gauche, stats et badge à droite
+                HStack(alignment: .center, spacing: FacioLayout.space16) {
+                    heroTitleBlock
+                    Spacer()
+                    heroStatsRow(heures: heures, brut: brut, net: net)
+                    heroInvoiceBadge
                 }
 
-                Spacer()
-
-                VStack(alignment: .trailing, spacing: FacioLayout.space4) {
-                    Text(L10n.totalHours(lang))
-                        .font(FacioFont.caption)
-                        .foregroundStyle(.secondary)
-                    Text("\(heures.formatted2Decimals(for: numberFormat))h")
-                        .font(FacioFont.amountEmphasis)
+                // Variante empilée : titre puis rangée stats + badge
+                VStack(alignment: .leading, spacing: FacioLayout.space10) {
+                    heroTitleBlock
+                    HStack(alignment: .center, spacing: FacioLayout.space16) {
+                        heroStatsRow(heures: heures, brut: brut, net: net)
+                        heroInvoiceBadge
+                    }
                 }
-
-                VStack(alignment: .trailing, spacing: FacioLayout.space4) {
-                    Text(L10n.grossTotal(lang))
-                        .font(FacioFont.caption)
-                        .foregroundStyle(.secondary)
-                    Text(brut.formatted2Decimals(for: numberFormat))
-                        .font(FacioFont.amountEmphasis)
-                }
-
-                VStack(alignment: .trailing, spacing: FacioLayout.space4) {
-                    Text(L10n.netTotal(lang))
-                        .font(FacioFont.caption)
-                        .foregroundStyle(.secondary)
-                    Text(net.formatted2Decimals(for: numberFormat))
-                        .font(FacioFont.amountEmphasis)
-                }
-
-                Text(timesheet.hasGeneratedInvoice ? L10n.invoiced(lang) : L10n.notInvoiced(lang))
-                    .font(FacioFont.caption)
-                    .fontWeight(.medium)
-                    .padding(.horizontal, FacioLayout.space8)
-                    .padding(.vertical, FacioLayout.space4)
-                    .background(invoiceTone.opacity(0.14))
-                    .foregroundStyle(invoiceTone)
-                    .clipShape(Capsule())
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
+    }
+
+    /// Bloc titre du hero (période + client), partagé par les variantes ViewThatFits.
+    private var heroTitleBlock: some View {
+        VStack(alignment: .leading, spacing: FacioLayout.space6) {
+            Text(timesheet.periodLabel(for: lang))
+                .font(FacioFont.heroTitle)
+            Text(timesheet.clientDisplayName.isEmpty ? L10n.noClient(lang) : timesheet.clientDisplayName)
+                .font(FacioFont.screenSubtitle)
+                .foregroundStyle(timesheet.clientDisplayName.isEmpty ? .tertiary : .secondary)
+        }
+    }
+
+    /// Rangée des trois statistiques du hero, partagée par les variantes ViewThatFits.
+    private func heroStatsRow(heures: Decimal, brut: Decimal, net: Decimal) -> some View {
+        HStack(alignment: .center, spacing: FacioLayout.space16) {
+            heroStat(L10n.totalHours(lang), value: "\(heures.formatted2Decimals(for: numberFormat))h")
+            heroStat(L10n.grossTotal(lang), value: brut.formatted2Decimals(for: numberFormat))
+            heroStat(L10n.netTotal(lang), value: net.formatted2Decimals(for: numberFormat))
+        }
+    }
+
+    /// Une statistique du hero (libellé + valeur).
+    private func heroStat(_ title: String, value: String) -> some View {
+        VStack(alignment: .trailing, spacing: FacioLayout.space4) {
+            Text(title)
+                .font(FacioFont.caption)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(FacioFont.amountEmphasis)
+        }
+    }
+
+    /// Badge facturé / non facturé du hero.
+    private var heroInvoiceBadge: some View {
+        let invoiceTone: Color = timesheet.hasGeneratedInvoice ? .intentSuccess : .intentWarning
+        return Text(timesheet.hasGeneratedInvoice ? L10n.invoiced(lang) : L10n.notInvoiced(lang))
+            .font(FacioFont.caption)
+            .fontWeight(.medium)
+            .padding(.horizontal, FacioLayout.space8)
+            .padding(.vertical, FacioLayout.space4)
+            .background(invoiceTone.opacity(0.14))
+            .foregroundStyle(invoiceTone)
+            .clipShape(Capsule())
     }
 
     private var periodRangeSection: some View {
@@ -380,43 +398,30 @@ struct TimesheetEditorView: View {
 
         return SectionPanel {
             VStack(spacing: FacioLayout.space10) {
-                // En-tete
-                HStack {
-                    VStack(alignment: .leading, spacing: FacioLayout.space2) {
-                        Text(L10n.week(lang, number: week.numero))
-                            .font(FacioFont.sectionTitle)
-                        Text(week.label(for: lang))
-                            .font(FacioFont.caption)
-                            .foregroundStyle(.secondary)
+                // En-tete : contenu 100% intrinsèque (Texts/Labels) → ViewThatFits autorisé.
+                ViewThatFits(in: .horizontal) {
+                    // Variante large : titre à gauche, stats à droite
+                    HStack {
+                        weekTitleBlock(week)
+                        Spacer()
+                        weekStatsRow(heuresMois: heuresMoisSemaine, norm: normSemaine, sup: supSemaine)
                     }
-                    Spacer()
-                    HStack(spacing: FacioLayout.space16) {
-                        Label("\(heuresMoisSemaine.formatted2Decimals(for: numberFormat))h", systemImage: "clock")
-                            .font(FacioFont.rowValue)
-                            .fontWeight(.medium)
-                        Text(L10n.normalHoursShort(lang, value: normSemaine.formatted2Decimals(for: numberFormat)))
-                            .font(FacioFont.metaValue)
-                            .foregroundStyle(Color.intentInfo)
-                        if supSemaine > 0 {
-                            Text(L10n.overtimeHoursShort(lang, value: supSemaine.formatted2Decimals(for: numberFormat)))
-                                .font(FacioFont.metaValue)
-                                .foregroundStyle(Color.intentWarning)
-                                .fontWeight(.medium)
-                        }
-                        Divider().frame(height: 14)
-                        let coutSemaine = normSemaine * timesheet.tauxNormal
-                            + supSemaine * timesheet.tauxSupplementaire
-                        Text(coutSemaine.formatted2Decimals(for: numberFormat))
-                            .font(FacioFont.rowValue)
-                            .fontWeight(.semibold)
-                            .foregroundStyle(Color.intentSuccess)
+
+                    // Variante empilée : titre puis rangée de stats
+                    VStack(alignment: .leading, spacing: FacioLayout.space8) {
+                        weekTitleBlock(week)
+                        weekStatsRow(heuresMois: heuresMoisSemaine, norm: normSemaine, sup: supSemaine)
                     }
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
 
                 Divider()
 
-                // Grille des jours
-                HStack(spacing: 0) {
+                // Grille des jours : wrap automatique en deux rangées quand la largeur se réduit
+                LazyVGrid(
+                    columns: [GridItem(.adaptive(minimum: 64, maximum: .infinity), spacing: FacioLayout.space4)],
+                    spacing: FacioLayout.space8
+                ) {
                     ForEach(Array(week.jours.enumerated()), id: \.offset) { dayIndex, jour in
                         let estDansMois = timesheet.isBillableDay(jour)
                         let hasTimerEntries = timesheet.hasTimeEntries(on: jour.dateString)
@@ -462,6 +467,41 @@ struct TimesheetEditorView: View {
                     }
                 }
             }
+        }
+    }
+
+    /// Bloc titre d'une semaine (numéro + plage), partagé par les variantes ViewThatFits.
+    private func weekTitleBlock(_ week: TimesheetWeek) -> some View {
+        VStack(alignment: .leading, spacing: FacioLayout.space2) {
+            Text(L10n.week(lang, number: week.numero))
+                .font(FacioFont.sectionTitle)
+            Text(week.label(for: lang))
+                .font(FacioFont.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    /// Rangée de stats d'une semaine (total, normales, sup, coût), partagée par les variantes ViewThatFits.
+    private func weekStatsRow(heuresMois: Decimal, norm: Decimal, sup: Decimal) -> some View {
+        HStack(spacing: FacioLayout.space16) {
+            Label("\(heuresMois.formatted2Decimals(for: numberFormat))h", systemImage: "clock")
+                .font(FacioFont.rowValue)
+                .fontWeight(.medium)
+            Text(L10n.normalHoursShort(lang, value: norm.formatted2Decimals(for: numberFormat)))
+                .font(FacioFont.metaValue)
+                .foregroundStyle(Color.intentInfo)
+            if sup > 0 {
+                Text(L10n.overtimeHoursShort(lang, value: sup.formatted2Decimals(for: numberFormat)))
+                    .font(FacioFont.metaValue)
+                    .foregroundStyle(Color.intentWarning)
+                    .fontWeight(.medium)
+            }
+            Divider().frame(height: 14)
+            let coutSemaine = norm * timesheet.tauxNormal + sup * timesheet.tauxSupplementaire
+            Text(coutSemaine.formatted2Decimals(for: numberFormat))
+                .font(FacioFont.rowValue)
+                .fontWeight(.semibold)
+                .foregroundStyle(Color.intentSuccess)
         }
     }
 

--- a/Facio/Views/Timesheet/TimesheetListView.swift
+++ b/Facio/Views/Timesheet/TimesheetListView.swift
@@ -267,7 +267,8 @@ struct TimesheetListView: View {
             }
         }
         .padding(FacioLayout.space20)
-        .frame(width: 400)
+        // Largeur souple : le popover se resserre sur les petites fenêtres.
+        .frame(minWidth: 360, idealWidth: 400, maxWidth: 440)
     }
 
     private func creerPeriode(client: ClientInfo?) {


### PR DESCRIPTION
## Contexte

PR3 du chantier UI/UX (plan validé). L'audit avait relevé ~15 layouts figés qui cassent en petite fenêtre. Plutôt que 15 rustines, cette PR pose une **stratégie unifiée** puis l'applique écran par écran.

## Infrastructure (`Views/Components/ResponsiveLayout.swift`)

- `\.facioWidthClass` (compact < 640 / regular / wide ≥ 1120) + `\.facioContainerWidth`, posés via `onGeometryChange` par ContentView (colonne détail) et **re-posés** là où la largeur réelle diffère (éditeur avec inspecteur, réglages).
- `AdaptiveStack` : HStack ↔ VStack via `AnyLayout` (préserve l'identité des vues, donc le focus des champs).
- `FormGrid` : LazyVGrid `.adaptive` pour les groupes de champs (wrap automatique).
- Règle documentée : `ViewThatFits` réservé au contenu 100 % intrinsèque ; dès qu'un TextField est présent → widthClass.

## Écrans

- **Éditeur de document** : en-tête (type/numéro/langue/statut) et champs client (postal/ville/siret/tva/ape) en `FormGrid` ; conversion comptable en `AdaptiveStack` ; totaux pleine largeur en compact ; **tableau de lignes en mode compact 2 niveaux** sous 700 pt (désignation pleine largeur + rangée qté/prix/TVA/total).
- **Clients** : split assoupli + **navigation empilée** liste ↔ détail avec bouton retour en compact.
- **Réglages** : suppression du min 700 pt, **sidebar icon-only 64 pt** avec tooltips en compact.
- **Timesheet** : héros et en-têtes de semaine en `ViewThatFits` (sous-vues partagées) ; **grille des 7 jours en colonnes flexibles** (7 en confortable, 4+3 en étroit).
- **Tracker & Planning** : saisie manuelle, barres de filtres et champs en `AdaptiveStack`/`FormGrid` ; header planning empilable.
- **Sheets** : aperçu PDF en `presentationSizing(.page)` (le min 850 pt était **clippé** dans une fenêtre de 640 !), signature en `.form`, picker client / palette ⌘K / popovers sur tokens.
- **Fenêtre minimale : 1060 → 960 pt** (`detailMin` 560 → 460), fait en dernier une fois tous les écrans adaptatifs.

## Revue adversariale (3 angles + réfutation) — corrigée avant push

- **[high]** Perte de saisie au franchissement du breakpoint du tableau de lignes (l'if/else détruit l'identité des `DecimalField`) → **commit de la valeur à chaque frappe**, plus aucune perte possible ✔
- Grille 7 jours : `.adaptive(minimum: 64)` créait des colonnes vides à droite en fenêtre large → compte fixe 7/4 en colonnes flexibles ✔
- Sheet d'entrée manuelle du planning oubliée à `width: 520` figé → tokens ✔
- `AdaptiveStack` aligné `.center` en rangée (fidèle aux HStack remplacés) ✔

## Vérification

- `swift build` 0 erreur 0 warning · `--run-regressions` : **80/80**, dont 3 nouveaux garde-fous (mapping des breakpoints, `sidebarMin+contentColumnMin+detailMin ≤ windowMinWidth`, mins des sheets ≤ fenêtre − 80).
- À l'œil avant merge : redimensionner 1280 → 960 en continu sur chaque écran (aucune coupure, le focus survit), clients en mode empilé, sidebar réglages repliée, aperçu PDF dans une fenêtre 960×640, grille 7 jours en 4+3.