### PR TITLE
impr(ui): micro-interactions sobres (FacioMotion)

### DIFF
--- a/Facio/Views/Components/DesignSystem.swift
+++ b/Facio/Views/Components/DesignSystem.swift
@@ -278,6 +278,7 @@ struct ActionTile: View {
     let action: () -> Void
 
     @State private var isHovering = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         Button(action: action) {
@@ -314,6 +315,7 @@ struct ActionTile: View {
                 .strokeBorder(isHovering ? Color.borderHover : Color.borderSubtle, lineWidth: 1)
         )
         .clipShape(RoundedRectangle(cornerRadius: FacioLayout.radiusPanel))
+        .animation(FacioMotion.respecting(FacioMotion.hover, reduceMotion: reduceMotion), value: isHovering)
         .onHover { isHovering = $0 }
     }
 }
@@ -323,6 +325,7 @@ struct FacioListRow<Content: View>: View {
     let content: Content
 
     @State private var isHovering = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     init(tone: Color = .primary, @ViewBuilder content: () -> Content) {
         self.tone = tone
@@ -345,6 +348,7 @@ struct FacioListRow<Content: View>: View {
         )
         .clipShape(RoundedRectangle(cornerRadius: FacioLayout.radiusRow))
         .contentShape(RoundedRectangle(cornerRadius: FacioLayout.radiusRow))
+        .animation(FacioMotion.respecting(FacioMotion.hover, reduceMotion: reduceMotion), value: isHovering)
         .onHover { isHovering = $0 }
     }
 }

--- a/Facio/Views/Components/FacioButton.swift
+++ b/Facio/Views/Components/FacioButton.swift
@@ -34,6 +34,7 @@ struct FacioButtonStyle: ButtonStyle {
 
     @Environment(\.isEnabled) private var isEnabled
     @Environment(\.facioAccent) private var ambientAccent
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
@@ -51,6 +52,7 @@ struct FacioButtonStyle: ButtonStyle {
             .clipShape(RoundedRectangle(cornerRadius: FacioLayout.radiusField))
             .contentShape(RoundedRectangle(cornerRadius: FacioLayout.radiusField))
             .opacity(isEnabled ? 1 : 0.45)
+            .animation(FacioMotion.respecting(FacioMotion.hover, reduceMotion: reduceMotion), value: configuration.isPressed)
     }
 
     private var fill: Color {
@@ -127,6 +129,7 @@ struct FacioIconButton: View {
     let action: () -> Void
 
     @State private var isHovering = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         Button(action: action) {
@@ -140,6 +143,7 @@ struct FacioIconButton: View {
         }
         .buttonStyle(.plain)
         .disabled(!isEnabled)
+        .animation(FacioMotion.respecting(FacioMotion.hover, reduceMotion: reduceMotion), value: isHovering)
         .onHover { isHovering = $0 }
         .help(help ?? "")
     }

--- a/Facio/Views/Components/FacioMotion.swift
+++ b/Facio/Views/Components/FacioMotion.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+/// Vocabulaire de motion de Facio — sobre et fermé.
+///
+/// Règle d'or : aucune `.animation()` nue ni durée magique dans les vues.
+/// Toute animation passe par un de ces tokens et est attachée à une `value:`
+/// précise (jamais d'animation implicite globale — certains écrans vivent
+/// dans une TimelineView à la seconde).
+///
+/// Respect de l'accessibilité : les vues qui animent lisent
+/// `@Environment(\.accessibilityReduceMotion)` et passent `nil` quand il est
+/// actif (helper `FacioMotion.respecting(_:reduceMotion:)`).
+///
+/// Exclusions volontaires (anti-gadget) : scroll des listes, transitions de
+/// navigation, compteurs KPI animés, apparition des états vides.
+enum FacioMotion {
+    /// Retour de survol (fonds, bordures) — quasi instantané.
+    static let hover: Animation = .easeOut(duration: 0.12)
+    /// Changement d'état local (drop zone, bascule d'inspecteur).
+    static let state: Animation = .snappy(duration: 0.18)
+    /// Apparition/disparition d'un élément ponctuel (undo bar, bannière).
+    static let emphasis: Animation = .spring(response: 0.32, dampingFraction: 0.86)
+
+    /// Glissement depuis le haut (bannières, undo bar).
+    static var slideIn: AnyTransition { .move(edge: .top).combined(with: .opacity) }
+    /// Glissement depuis le bas (toasts).
+    static var slideUp: AnyTransition { .move(edge: .bottom).combined(with: .opacity) }
+
+    /// Annule l'animation quand « Réduire les animations » est actif.
+    static func respecting(_ animation: Animation, reduceMotion: Bool) -> Animation? {
+        reduceMotion ? nil : animation
+    }
+}

--- a/Facio/Views/Documents/DocumentAttachmentsSection.swift
+++ b/Facio/Views/Documents/DocumentAttachmentsSection.swift
@@ -12,6 +12,7 @@ struct DocumentAttachmentsSection: View {
 
     @State private var isDropTargeted = false
     @State private var failedImportCount = 0
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         SectionPanel(L10n.attachmentsSection(lang), systemImage: "paperclip") {
@@ -57,9 +58,10 @@ struct DocumentAttachmentsSection: View {
     private var dropZone: some View {
         ZStack {
             RoundedRectangle(cornerRadius: FacioLayout.radiusPanel)
+                .fill(isDropTargeted ? Color.appPrimary(from: dataStore.companyInfo).opacity(0.06) : .clear)
+            RoundedRectangle(cornerRadius: FacioLayout.radiusPanel)
                 .strokeBorder(style: StrokeStyle(lineWidth: 2, dash: [6]))
                 .foregroundStyle(isDropTargeted ? Color.intentInfo : .secondary.opacity(0.4))
-                .frame(height: 60)
 
             VStack(spacing: FacioLayout.space4) {
                 Image(systemName: "paperclip.badge.ellipsis")
@@ -70,6 +72,9 @@ struct DocumentAttachmentsSection: View {
                     .foregroundStyle(.secondary)
             }
         }
+        .frame(height: 60)
+        .scaleEffect(isDropTargeted ? 1.01 : 1.0)
+        .animation(FacioMotion.respecting(FacioMotion.state, reduceMotion: reduceMotion), value: isDropTargeted)
         .onDrop(of: [.fileURL], isTargeted: $isDropTargeted) { providers in
             handleDrop(providers)
         }

--- a/Facio/Views/Documents/DocumentEditorView.swift
+++ b/Facio/Views/Documents/DocumentEditorView.swift
@@ -13,6 +13,7 @@ struct DocumentEditorView: View {
     @State private var attachmentCopyFailures = 0
     @State private var showAttachmentCopyAlert = false
     @State private var showEmailUnavailableAlert = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var signatureCountBeforeSheet = 0
 
     // Debounce timer for auto-save
@@ -81,6 +82,8 @@ struct DocumentEditorView: View {
                     documentInspector
                 }
             }
+            // Apparition/masquage de l'inspecteur au franchissement du breakpoint.
+            .animation(FacioMotion.respecting(FacioMotion.state, reduceMotion: reduceMotion), value: usesSideInspector)
         }
         .navigationTitle(document.number.isEmpty ? L10n.newDocument(lang) : document.number)
         .toolbar {

--- a/Facio/Views/Timesheet/TimeTrackerPanel.swift
+++ b/Facio/Views/Timesheet/TimeTrackerPanel.swift
@@ -57,6 +57,7 @@ struct TimeTrackerPanel: View {
     @State private var editingEntryId: UUID?
     @State private var validationMessage: String?
     @State private var deletedUndo: DeletedTimeEntryUndo?
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private var lang: AppLanguage { dataStore.companyInfo.langueParDefaut }
     private var numberFormat: AppLanguage { dataStore.companyInfo.formatNombre }
@@ -370,13 +371,16 @@ struct TimeTrackerPanel: View {
                     .font(.subheadline)
                 Button(L10n.undo(lang)) {
                     dataStore.restoreTimeEntry(deletedUndo.entry, in: timesheet)
-                    self.deletedUndo = nil
+                    withAnimation(FacioMotion.respecting(FacioMotion.emphasis, reduceMotion: reduceMotion)) {
+                        self.deletedUndo = nil
+                    }
                 }
                 Spacer()
             }
             .padding(FacioLayout.space10)
             .background(Color.intentWarning.opacity(0.12))
             .clipShape(RoundedRectangle(cornerRadius: FacioLayout.radiusPanel))
+            .transition(FacioMotion.slideIn)
         }
     }
 
@@ -620,13 +624,17 @@ struct TimeTrackerPanel: View {
 
     private func deleteWithUndo(_ entry: TimeEntry) {
         dataStore.deleteTimeEntry(entry, from: timesheet)
-        deletedUndo = DeletedTimeEntryUndo(id: entry.id, entry: entry)
+        withAnimation(FacioMotion.respecting(FacioMotion.emphasis, reduceMotion: reduceMotion)) {
+            deletedUndo = DeletedTimeEntryUndo(id: entry.id, entry: entry)
+        }
         let deletedId = entry.id
         Task {
             try? await Task.sleep(nanoseconds: 20_000_000_000)
             await MainActor.run {
                 if deletedUndo?.id == deletedId {
-                    deletedUndo = nil
+                    withAnimation(FacioMotion.respecting(FacioMotion.emphasis, reduceMotion: reduceMotion)) {
+                        deletedUndo = nil
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Contexte

PR5 du chantier UI/UX (plan validé), **empilée sur #83** (responsive) — à recibler sur `main` après son merge. L'app n'avait **aucune** animation (0 `withAnimation`, 0 `.animation`).

## Changements

**`Views/Components/FacioMotion.swift`** : vocabulaire de motion fermé — `hover` (easeOut 0,12 s), `state` (snappy 0,18 s), `emphasis` (spring 0,32 s), transitions `slideIn`/`slideUp`. Règle documentée : aucune `.animation()` nue, toujours attachée à une `value:` ; helper `respecting(_:reduceMotion:)` pour l'accessibilité.

**Liste blanche appliquée (6 emplacements, rien d'autre)** :
1. Survol `ActionTile` / `FacioListRow` (fond + bordure).
2. Pressed `FacioButtonStyle` + survol `FacioIconButton`.
3. Zone de dépôt des justificatifs : teinte accent 6 % + scale 1,01.
4. Undo bar du tracker : glissement d'apparition/disparition (`withAnimation` autour des 3 mutations — **aucune animation implicite** dans la TimelineView à 1 s).
5. Inspecteur de l'éditeur : transition douce au franchissement du breakpoint 1120.
6. Tous les sites lisent `accessibilityReduceMotion` → tout devient instantané avec « Réduire les animations ».

Exclusions volontaires (anti-gadget) : scroll, navigation, compteurs KPI, états vides.

## Vérification

`swift build` 0 erreur 0 warning · `--run-regressions` **80/80**. À l'œil : survoler tuiles/boutons (~120 ms, pas de flash), glisser un fichier sur la zone de dépôt, supprimer une entrée de temps (l'undo bar glisse), activer « Réduire les animations » → tout instantané.