### PR TITLE
feat(ux): retours visuels — toasts, confirmations et CTA

### DIFF
--- a/Facio/FacioApp.swift
+++ b/Facio/FacioApp.swift
@@ -97,6 +97,7 @@ struct FacioApp: App {
                 .environment(dataStore)
                 .environment(syncService)
                 .environment(authService)
+                .environment(toastCenter)
                 .environment(\.facioAccent, Color.appPrimary(from: dataStore.companyInfo))
                 .tint(Color.appPrimary(from: dataStore.companyInfo))
         }

--- a/Facio/FacioApp.swift
+++ b/Facio/FacioApp.swift
@@ -8,6 +8,7 @@ struct FacioApp: App {
     @State private var authService: AuthService
     @State private var networkMonitor: NetworkMonitor
     @State private var updateService: UpdateService
+    @State private var toastCenter = ToastCenter()
     @State private var showFirstLaunch = false
 
     init() {
@@ -33,6 +34,7 @@ struct FacioApp: App {
                 .environment(syncService)
                 .environment(authService)
                 .environment(networkMonitor)
+                .environment(toastCenter)
                 .environment(\.facioAccent, Color.appPrimary(from: dataStore.companyInfo))
                 .tint(Color.appPrimary(from: dataStore.companyInfo))
                 .frame(minWidth: FacioLayout.windowMinWidth, minHeight: FacioLayout.windowMinHeight)

--- a/Facio/Localization/L10n+UX.swift
+++ b/Facio/Localization/L10n+UX.swift
@@ -65,6 +65,9 @@ extension L10n {
         l == .fr ? "Email préparé dans votre messagerie" : "Email drafted in your mail app"
     }
     static func toastCSVExported(_ l: AppLanguage) -> String { l == .fr ? "CSV exporté" : "CSV exported" }
+    static func toastCSVExportFailed(_ l: AppLanguage) -> String {
+        l == .fr ? "Export CSV impossible" : "CSV export failed"
+    }
     static func toastAttachmentsAdded(_ l: AppLanguage, count: Int) -> String {
         if l == .fr {
             return count == 1 ? "1 justificatif ajouté" : "\(count) justificatifs ajoutés"

--- a/Facio/Localization/L10n+UX.swift
+++ b/Facio/Localization/L10n+UX.swift
@@ -58,4 +58,35 @@ extension L10n {
     static func noSearchResultsHint(_ l: AppLanguage) -> String {
         l == .fr ? "Essayez un autre mot-clé ou vérifiez les filtres." : "Try another keyword or check the filters."
     }
+
+    // Toasts (retours non bloquants)
+    static func toastPDFExported(_ l: AppLanguage) -> String { l == .fr ? "PDF exporté" : "PDF exported" }
+    static func toastEmailComposed(_ l: AppLanguage) -> String {
+        l == .fr ? "Email préparé dans votre messagerie" : "Email drafted in your mail app"
+    }
+    static func toastCSVExported(_ l: AppLanguage) -> String { l == .fr ? "CSV exporté" : "CSV exported" }
+    static func toastAttachmentsAdded(_ l: AppLanguage, count: Int) -> String {
+        if l == .fr {
+            return count == 1 ? "1 justificatif ajouté" : "\(count) justificatifs ajoutés"
+        }
+        return count == 1 ? "1 supporting document added" : "\(count) supporting documents added"
+    }
+
+    // Confirmations destructives
+    static func deletePeriodConfirmTitle(_ l: AppLanguage) -> String {
+        l == .fr ? "Supprimer cette période ?" : "Delete this period?"
+    }
+    static func deletePeriodConfirmMessage(_ l: AppLanguage, label: String) -> String {
+        l == .fr
+            ? "La période \(label) et toutes ses heures saisies seront supprimées définitivement."
+            : "Period \(label) and all its recorded hours will be permanently deleted."
+    }
+    static func deleteAttachmentConfirmTitle(_ l: AppLanguage) -> String {
+        l == .fr ? "Supprimer ce justificatif ?" : "Delete this supporting document?"
+    }
+    static func deleteAttachmentConfirmMessage(_ l: AppLanguage, name: String) -> String {
+        l == .fr
+            ? "Le fichier « \(name) » sera supprimé définitivement du disque."
+            : "The file “\(name)” will be permanently deleted from disk."
+    }
 }

--- a/Facio/Views/Components/FacioToast.swift
+++ b/Facio/Views/Components/FacioToast.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+/// Toast non bloquant affiché en bas de la fenêtre principale.
+///
+/// Hiérarchie des retours visuels de Facio :
+/// - **toast** : succès / information non bloquante (export, envoi, import) ;
+/// - **InlineWarning** : erreur contextuelle persistante dans un panneau ;
+/// - **alert** : erreur bloquante nécessitant une décision.
+///
+/// L'hôte est posé une seule fois sur la racine de `ContentView` — les toasts
+/// n'apparaissent pas au-dessus des sheets (assumé : les sheets gardent leurs
+/// retours inline).
+struct FacioToastData: Identifiable, Equatable {
+    let id = UUID()
+    let message: String
+    let tone: InlineTone
+    var icon: String?
+}
+
+@MainActor
+@Observable
+final class ToastCenter {
+    private(set) var current: FacioToastData?
+    private var dismissTask: Task<Void, Never>?
+
+    /// Affiche un toast 3 s ; un nouveau toast remplace le précédent.
+    func show(_ message: String, tone: InlineTone = .success, icon: String? = nil) {
+        let toast = FacioToastData(message: message, tone: tone, icon: icon)
+        withAnimation(FacioMotion.emphasis) {
+            current = toast
+        }
+        dismissTask?.cancel()
+        dismissTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 3_000_000_000)
+            guard let self, self.current?.id == toast.id, !Task.isCancelled else { return }
+            withAnimation(FacioMotion.emphasis) {
+                self.current = nil
+            }
+        }
+    }
+}
+
+private struct FacioToastHost: ViewModifier {
+    @Environment(ToastCenter.self) private var toastCenter
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    func body(content: Content) -> some View {
+        content.overlay(alignment: .bottom) {
+            if let toast = toastCenter.current {
+                HStack(spacing: FacioLayout.space8) {
+                    Image(systemName: toast.icon ?? toast.tone.icon)
+                        .foregroundStyle(toast.tone.color)
+                    Text(toast.message)
+                        .font(FacioFont.rowTitle)
+                }
+                .padding(.horizontal, FacioLayout.space16)
+                .padding(.vertical, FacioLayout.space10)
+                .background(Color.surfacePanel, in: Capsule())
+                .overlay(Capsule().strokeBorder(toast.tone.color.opacity(0.35), lineWidth: 1))
+                .shadow(color: .black.opacity(0.12), radius: 8, y: 2)
+                .padding(.bottom, FacioLayout.space20)
+                .allowsHitTesting(false)
+                .transition(FacioMotion.slideUp)
+                .transaction { transaction in
+                    if reduceMotion { transaction.animation = nil }
+                }
+            }
+        }
+    }
+}
+
+extension View {
+    /// Pose l'hôte des toasts. À appliquer une seule fois, sur la racine de la
+    /// fenêtre principale.
+    func facioToastHost() -> some View {
+        modifier(FacioToastHost())
+    }
+}

--- a/Facio/Views/Components/FacioToast.swift
+++ b/Facio/Views/Components/FacioToast.swift
@@ -29,6 +29,8 @@ final class ToastCenter {
         withAnimation(FacioMotion.emphasis) {
             current = toast
         }
+        // Message transitoire et non focusable : annoncé à VoiceOver.
+        AccessibilityNotification.Announcement(message).post()
         dismissTask?.cancel()
         dismissTask = Task { [weak self] in
             try? await Task.sleep(nanoseconds: 3_000_000_000)

--- a/Facio/Views/ContentView.swift
+++ b/Facio/Views/ContentView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ContentView: View {
     @Environment(DataStore.self) private var dataStore
+    @Environment(ToastCenter.self) private var toastCenter
     @State private var selectedSection: SidebarSection? = .dashboard
     @State private var selectedDocumentId: UUID?
     @State private var selectedTimesheetId: UUID?
@@ -58,6 +59,14 @@ struct ContentView: View {
             }
         }
         .navigationSplitViewStyle(.balanced)
+        .facioToastHost()
+        // Les erreurs de persistance étaient remplies par DataStore mais
+        // jamais affichées : on les fait remonter en toast non bloquant.
+        .onChange(of: dataStore.persistenceErrors) { _, errors in
+            if let message = errors.values.first {
+                toastCenter.show(message, tone: .danger)
+            }
+        }
         .sheet(isPresented: $showCommandPalette) {
             CommandPaletteView(
                 selectedSection: $selectedSection,
@@ -175,7 +184,14 @@ struct ContentView: View {
                     title: L10n.noDocumentSelected(lang),
                     systemImage: "doc.text",
                     message: L10n.selectDocumentHint(lang)
-                )
+                ) {
+                    FacioButton(
+                        selectedSection == .devis ? L10n.quickCreateQuote(lang) : L10n.quickCreateInvoice(lang),
+                        systemImage: "plus"
+                    ) {
+                        newDocument(selectedSection == .devis ? .devis : .facture)
+                    }
+                }
             }
         case .heures:
             if let ts = selectedTimesheet {

--- a/Facio/Views/ContentView.swift
+++ b/Facio/Views/ContentView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 struct ContentView: View {
     @Environment(DataStore.self) private var dataStore
-    @Environment(ToastCenter.self) private var toastCenter
     @State private var selectedSection: SidebarSection? = .dashboard
     @State private var selectedDocumentId: UUID?
     @State private var selectedTimesheetId: UUID?
@@ -60,11 +59,19 @@ struct ContentView: View {
         }
         .navigationSplitViewStyle(.balanced)
         .facioToastHost()
-        // Les erreurs de persistance étaient remplies par DataStore mais
-        // jamais affichées : on les fait remonter en toast non bloquant.
-        .onChange(of: dataStore.persistenceErrors) { _, errors in
-            if let message = errors.values.first {
-                toastCenter.show(message, tone: .danger)
+        // Les erreurs de persistance (risque de perte de données, chemin de
+        // backup à noter) sont persistantes : bannière pilotée par l'état —
+        // visible dès le lancement et tant que l'erreur n'est pas résolue —
+        // et non un toast éphémère (hiérarchie documentée dans FacioToast).
+        .overlay(alignment: .top) {
+            if !dataStore.persistenceErrors.isEmpty {
+                VStack(alignment: .leading, spacing: FacioLayout.space4) {
+                    ForEach(dataStore.persistenceErrors.sorted(by: { $0.key < $1.key }), id: \.key) { _, message in
+                        InlineWarning(text: message, tone: .danger)
+                    }
+                }
+                .frame(maxWidth: 560)
+                .padding(.top, FacioLayout.space8)
             }
         }
         .sheet(isPresented: $showCommandPalette) {

--- a/Facio/Views/Documents/DocumentAttachmentsSection.swift
+++ b/Facio/Views/Documents/DocumentAttachmentsSection.swift
@@ -12,7 +12,10 @@ struct DocumentAttachmentsSection: View {
 
     @State private var isDropTargeted = false
     @State private var failedImportCount = 0
+    @State private var dropAddedCount = 0
+    @State private var attachmentPendingDeletion: DocumentAttachment?
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(ToastCenter.self) private var toastCenter
 
     var body: some View {
         SectionPanel(L10n.attachmentsSection(lang), systemImage: "paperclip") {
@@ -30,7 +33,7 @@ struct DocumentAttachmentsSection: View {
                                 attachment: attachment,
                                 lang: lang,
                                 onOpen: { open(attachment) },
-                                onDelete: { dataStore.deleteAttachment(attachment, from: document) }
+                                onDelete: { attachmentPendingDeletion = attachment }
                             )
                             if attachment.id != document.attachments.last?.id {
                                 Divider()
@@ -52,6 +55,30 @@ struct DocumentAttachmentsSection: View {
                 }
                 .buttonStyle(.borderless)
             }
+        }
+        // Suppression définitive (le fichier disque part avec) : confirmation
+        // obligatoire — contrairement aux entrées de temps, pas d'undo possible.
+        .alert(
+            L10n.deleteAttachmentConfirmTitle(lang),
+            isPresented: Binding(
+                get: { attachmentPendingDeletion != nil },
+                set: { if !$0 { attachmentPendingDeletion = nil } }
+            )
+        ) {
+            Button(L10n.cancel(lang), role: .cancel) {
+                attachmentPendingDeletion = nil
+            }
+            Button(L10n.delete(lang), role: .destructive) {
+                if let attachment = attachmentPendingDeletion {
+                    dataStore.deleteAttachment(attachment, from: document)
+                }
+                attachmentPendingDeletion = nil
+            }
+        } message: {
+            Text(L10n.deleteAttachmentConfirmMessage(
+                lang,
+                name: attachmentPendingDeletion?.originalFilename ?? ""
+            ))
         }
     }
 
@@ -96,8 +123,16 @@ struct DocumentAttachmentsSection: View {
         panel.canChooseDirectories = false
         guard panel.runModal() == .OK else { return }
         failedImportCount = 0
-        for url in panel.urls where dataStore.importAttachment(from: url, to: document) == nil {
-            failedImportCount += 1
+        var added = 0
+        for url in panel.urls {
+            if dataStore.importAttachment(from: url, to: document) == nil {
+                failedImportCount += 1
+            } else {
+                added += 1
+            }
+        }
+        if added > 0 {
+            toastCenter.show(L10n.toastAttachmentsAdded(lang, count: added), icon: "paperclip")
         }
     }
 
@@ -116,11 +151,25 @@ struct DocumentAttachmentsSection: View {
                     }
                     if dataStore.importAttachment(from: url, to: document) == nil {
                         failedImportCount += 1
+                    } else {
+                        dropAddedCount += 1
+                        scheduleDropToast()
                     }
                 }
             }
         }
         return handledAny
+    }
+
+    /// Les imports d'un glisser-déposer arrivent dans des callbacks asynchrones :
+    /// on agrège brièvement avant d'afficher un seul toast pour tout le lot.
+    private func scheduleDropToast() {
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 300_000_000)
+            guard dropAddedCount > 0 else { return }
+            toastCenter.show(L10n.toastAttachmentsAdded(lang, count: dropAddedCount), icon: "paperclip")
+            dropAddedCount = 0
+        }
     }
 }
 

--- a/Facio/Views/Documents/DocumentAttachmentsSection.swift
+++ b/Facio/Views/Documents/DocumentAttachmentsSection.swift
@@ -13,6 +13,7 @@ struct DocumentAttachmentsSection: View {
     @State private var isDropTargeted = false
     @State private var failedImportCount = 0
     @State private var dropAddedCount = 0
+    @State private var dropToastTask: Task<Void, Never>?
     @State private var attachmentPendingDeletion: DocumentAttachment?
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(ToastCenter.self) private var toastCenter
@@ -162,11 +163,12 @@ struct DocumentAttachmentsSection: View {
     }
 
     /// Les imports d'un glisser-déposer arrivent dans des callbacks asynchrones :
-    /// on agrège brièvement avant d'afficher un seul toast pour tout le lot.
+    /// on agrège (debounce 300 ms) avant d'afficher un seul toast pour le lot.
     private func scheduleDropToast() {
-        Task { @MainActor in
+        dropToastTask?.cancel()
+        dropToastTask = Task { @MainActor in
             try? await Task.sleep(nanoseconds: 300_000_000)
-            guard dropAddedCount > 0 else { return }
+            guard !Task.isCancelled, dropAddedCount > 0 else { return }
             toastCenter.show(L10n.toastAttachmentsAdded(lang, count: dropAddedCount), icon: "paperclip")
             dropAddedCount = 0
         }

--- a/Facio/Views/Documents/DocumentEditorView.swift
+++ b/Facio/Views/Documents/DocumentEditorView.swift
@@ -14,6 +14,7 @@ struct DocumentEditorView: View {
     @State private var showAttachmentCopyAlert = false
     @State private var showEmailUnavailableAlert = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(ToastCenter.self) private var toastCenter
     @State private var signatureCountBeforeSheet = 0
 
     // Debounce timer for auto-save
@@ -382,24 +383,28 @@ struct DocumentEditorView: View {
             } label: {
                 Label(L10n.duplicate(lang), systemImage: "doc.on.doc")
             }
+            .help(L10n.duplicate(lang))
 
             Button {
                 showPreview = true
             } label: {
                 Label(L10n.preview(lang), systemImage: "eye")
             }
+            .help(L10n.preview(lang))
 
             Button {
                 exporterPDF()
             } label: {
                 Label(L10n.exportPDF(lang), systemImage: "square.and.arrow.up")
             }
+            .help(L10n.exportPDF(lang))
 
             Button {
                 envoyerParEmail()
             } label: {
                 Label(L10n.sendByEmail(lang), systemImage: "paperplane")
             }
+            .help(L10n.sendByEmail(lang))
         }
     }
 
@@ -759,8 +764,13 @@ struct DocumentEditorView: View {
 
         Task {
             let result = await ExportService.exportPDF(data: pdfData, defaultFilename: document.number, language: lang)
-            if result == .failed {
+            switch result {
+            case .success:
+                toastCenter.show(L10n.toastPDFExported(lang), icon: "square.and.arrow.up")
+            case .failed:
                 showPDFExportAlert = true
+            case .cancelled:
+                break
             }
         }
     }
@@ -785,7 +795,10 @@ struct DocumentEditorView: View {
             pdfData: pdfData,
             attachmentURLs: attachmentURLs
         )
-        if result == .unavailable {
+        switch result {
+        case .composed:
+            toastCenter.show(L10n.toastEmailComposed(lang), icon: "paperplane")
+        case .unavailable:
             showEmailUnavailableAlert = true
         }
     }

--- a/Facio/Views/Documents/DocumentListView.swift
+++ b/Facio/Views/Documents/DocumentListView.swift
@@ -88,7 +88,16 @@ struct DocumentListView: View {
                     message: searchText.isEmpty
                         ? L10n.clickToCreate(lang, type: documentType.label(for: lang).lowercased())
                         : L10n.noSearchResultsHint(lang)
-                )
+                ) {
+                    if searchText.isEmpty {
+                        FacioButton(
+                            documentType == .devis ? L10n.quickCreateQuote(lang) : L10n.quickCreateInvoice(lang),
+                            systemImage: "plus"
+                        ) {
+                            creerDocument()
+                        }
+                    }
+                }
             }
         }
         .alert(L10n.deleteDocumentConfirmTitle(lang), isPresented: Binding(

--- a/Facio/Views/Timesheet/TimeTrackerPanel.swift
+++ b/Facio/Views/Timesheet/TimeTrackerPanel.swift
@@ -58,6 +58,7 @@ struct TimeTrackerPanel: View {
     @State private var validationMessage: String?
     @State private var deletedUndo: DeletedTimeEntryUndo?
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(ToastCenter.self) private var toastCenter
 
     private var lang: AppLanguage { dataStore.companyInfo.langueParDefaut }
     private var numberFormat: AppLanguage { dataStore.companyInfo.formatNombre }
@@ -614,11 +615,14 @@ struct TimeTrackerPanel: View {
         )
         guard let data = csv.data(using: .utf8) else { return }
         Task {
-            _ = await ExportService.exportCSV(
+            let result = await ExportService.exportCSV(
                 data: data,
                 defaultFilename: "\(L10n.defaultCSVName(lang))-\(timesheet.activeStartDateString)-\(timesheet.activeEndDateString)",
                 language: lang
             )
+            if result == .success {
+                toastCenter.show(L10n.toastCSVExported(lang), icon: "tablecells")
+            }
         }
     }
 

--- a/Facio/Views/Timesheet/TimeTrackerPanel.swift
+++ b/Facio/Views/Timesheet/TimeTrackerPanel.swift
@@ -620,8 +620,13 @@ struct TimeTrackerPanel: View {
                 defaultFilename: "\(L10n.defaultCSVName(lang))-\(timesheet.activeStartDateString)-\(timesheet.activeEndDateString)",
                 language: lang
             )
-            if result == .success {
+            switch result {
+            case .success:
                 toastCenter.show(L10n.toastCSVExported(lang), icon: "tablecells")
+            case .failed:
+                toastCenter.show(L10n.toastCSVExportFailed(lang), tone: .danger)
+            case .cancelled:
+                break
             }
         }
     }

--- a/Facio/Views/Timesheet/TimesheetListView.swift
+++ b/Facio/Views/Timesheet/TimesheetListView.swift
@@ -122,16 +122,7 @@ struct TimesheetListView: View {
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Button {
-                    // Reset au mois courant a chaque ouverture
-                    let cal = Calendar.current
-                    let now = Date()
-                    newPeriodMode = .month
-                    selectedMois = cal.component(.month, from: now)
-                    selectedAnnee = cal.component(.year, from: now)
-                    selectedStartDate = now
-                    selectedEndDate = now
-                    selectedClientId = nil
-                    showNewPeriod = true
+                    presentNewPeriod()
                 } label: {
                     Label(L10n.newPeriod(lang), systemImage: "plus")
                 }
@@ -190,11 +181,25 @@ struct TimesheetListView: View {
                     message: L10n.clickToCreatePeriod(lang)
                 ) {
                     FacioButton(L10n.newPeriod(lang), systemImage: "plus") {
-                        showNewPeriod = true
+                        presentNewPeriod()
                     }
                 }
             }
         }
+    }
+
+    /// Réinitialise le brouillon de période (mois courant) puis ouvre le popover.
+    /// Partagé entre le bouton de toolbar et le CTA de l'état vide.
+    private func presentNewPeriod() {
+        let cal = Calendar.current
+        let now = Date()
+        newPeriodMode = .month
+        selectedMois = cal.component(.month, from: now)
+        selectedAnnee = cal.component(.year, from: now)
+        selectedStartDate = now
+        selectedEndDate = now
+        selectedClientId = nil
+        showNewPeriod = true
     }
 
     // MARK: - Popover nouvelle periode

--- a/Facio/Views/Timesheet/TimesheetListView.swift
+++ b/Facio/Views/Timesheet/TimesheetListView.swift
@@ -13,6 +13,7 @@ struct TimesheetListView: View {
 
     @Environment(DataStore.self) private var dataStore
     @State private var showNewPeriod = false
+    @State private var timesheetPendingDeletion: TimesheetPeriod?
     @State private var showInvoiceDetailOptions = false
     @State private var newPeriodMode: NewTimesheetPeriodMode = .month
     @State private var selectedMois: Int = Calendar.current.component(.month, from: Date())
@@ -109,8 +110,7 @@ struct TimesheetListView: View {
                         }
                         Divider()
                         Button(role: .destructive) {
-                            if selectedTimesheetId == ts.id { selectedTimesheetId = nil }
-                            dataStore.deleteTimesheet(ts)
+                            timesheetPendingDeletion = ts
                         } label: {
                             Label(L10n.delete(lang), systemImage: "trash")
                         }
@@ -159,13 +159,40 @@ struct TimesheetListView: View {
         } message: { _ in
             Text(L10n.chooseInvoiceDetail(lang))
         }
+        .alert(
+            L10n.deletePeriodConfirmTitle(lang),
+            isPresented: Binding(
+                get: { timesheetPendingDeletion != nil },
+                set: { if !$0 { timesheetPendingDeletion = nil } }
+            )
+        ) {
+            Button(L10n.cancel(lang), role: .cancel) {
+                timesheetPendingDeletion = nil
+            }
+            Button(L10n.delete(lang), role: .destructive) {
+                if let ts = timesheetPendingDeletion {
+                    if selectedTimesheetId == ts.id { selectedTimesheetId = nil }
+                    dataStore.deleteTimesheet(ts)
+                }
+                timesheetPendingDeletion = nil
+            }
+        } message: {
+            Text(L10n.deletePeriodConfirmMessage(
+                lang,
+                label: timesheetPendingDeletion?.periodLabel(for: lang) ?? ""
+            ))
+        }
         .overlay {
             if timesheets.isEmpty {
                 FacioEmptyState(
                     title: L10n.noPeriod(lang),
                     systemImage: "clock",
                     message: L10n.clickToCreatePeriod(lang)
-                )
+                ) {
+                    FacioButton(L10n.newPeriod(lang), systemImage: "plus") {
+                        showNewPeriod = true
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Contexte

PR6 du chantier UI/UX (plan validé), **empilée sur #84** — à recibler après merge. Seul `feat:` du chantier (bump minor). Avant cette PR : aucun retour après un export ou un envoi, **erreurs de sauvegarde silencieuses** (`DataStore.persistenceErrors` rempli mais jamais affiché), suppressions destructives sans confirmation.

## Changements

**`Views/Components/FacioToast.swift`** : `ToastCenter` (@Observable, toast 3 s, remplacement du courant) + `.facioToastHost()` posé une fois sur la racine de ContentView. Hiérarchie documentée : toast = succès/info · InlineWarning = erreur contextuelle · alert = bloquant. Respecte « Réduire les animations ».

**Branchements** :
- Export PDF → toast « PDF exporté » (échec → alerte existante, annulation → rien).
- Envoi email → toast « Email préparé dans votre messagerie ».
- Export CSV du tracker → toast (le résultat était ignoré via `_ =`).
- Import de justificatifs → toast « N justificatifs ajoutés » (agrégé pour le glisser-déposer asynchrone).
- **`persistenceErrors` enfin visible** : toute erreur d'écriture disque remonte en toast danger (messages déjà localisés).

**Confirmations destructives** (irréversibles, fichiers/heures perdus) :
- Suppression de période de timesheet (menu contextuel) → alerte avec le libellé de la période.
- Suppression de justificatif (le fichier disque part avec) → alerte avec le nom du fichier.
- L'undo-bar des entrées de temps est conservée (pattern supérieur pour une action fréquente et réversible).

**CTA dans les états vides** : listes factures/devis et périodes + panneaux de détail vides → bouton de création directe (libellés L10n existants réutilisés).

**Tooltips** : les 4 boutons de la toolbar de l'éditeur.

Nouvelles chaînes dans `L10n+UX.swift`, **FR + EN**.

## Vérification

`swift build` 0 erreur 0 warning · `--run-regressions` **80/80**. À l'œil : exporter un PDF (toast), annuler (rien), envoyer par email, dropper 3 fichiers dont 1 invalide (1 avertissement agrégé + toast « 2 ajoutés »), supprimer une période/un justificatif (confirmations), états vides → CTA, rendre `~/Library/Application Support/Facio` non inscriptible → toast danger.