### PR TITLE
impr(theme): dark mode soigné — variantes sombres des tokens

### DIFF
--- a/Facio/Diagnostics/RegressionSuite.swift
+++ b/Facio/Diagnostics/RegressionSuite.swift
@@ -2,6 +2,7 @@
 import Darwin
 import Foundation
 import PDFKit
+import SwiftUI
 
 @MainActor
 enum FacioRegressionSuite {
@@ -119,8 +120,37 @@ enum FacioRegressionSuite {
         RegressionCase(name: "pdf generation paginates long invoices", run: pdfGenerationPaginatesLongInvoices),
         RegressionCase(name: "responsive width class maps breakpoints", run: responsiveWidthClassMapsBreakpoints),
         RegressionCase(name: "window minimum fits split view columns", run: windowMinimumFitsSplitViewColumns),
-        RegressionCase(name: "sheet minimums fit inside minimum window", run: sheetMinimumsFitInsideMinimumWindow)
+        RegressionCase(name: "sheet minimums fit inside minimum window", run: sheetMinimumsFitInsideMinimumWindow),
+        RegressionCase(name: "color tokens resolve differently in dark mode", run: colorTokensResolveDifferentlyInDarkMode)
     ]
+
+    /// Garde-fou dark mode : les tokens doivent se résoudre différemment selon
+    /// le colorScheme via le chemin de rendu SwiftUI (Color.resolve(in:)) —
+    /// attrape les couleurs figées par une résolution prématurée.
+    private static func colorTokensResolveDifferentlyInDarkMode() throws {
+        var lightEnv = EnvironmentValues()
+        lightEnv.colorScheme = .light
+        var darkEnv = EnvironmentValues()
+        darkEnv.colorScheme = .dark
+
+        func components(_ color: Color, _ env: EnvironmentValues) -> String {
+            let r = color.resolve(in: env)
+            return "\(r.red) \(r.green) \(r.blue) \(r.opacity)"
+        }
+
+        let tokens: [(String, Color)] = [
+            ("surfacePanel", .surfacePanel),
+            ("surfaceField", .surfaceField),
+            ("borderSubtle", .borderSubtle),
+            ("appPrimary", .appPrimary)
+        ]
+        for (name, token) in tokens {
+            try expect(
+                components(token, lightEnv) != components(token, darkEnv),
+                "\(name) should resolve to different colors in light and dark mode"
+            )
+        }
+    }
 
     private static func responsiveWidthClassMapsBreakpoints() throws {
         try expectEqual(FacioWidthClass(width: FacioLayout.breakpointCompact - 1), .compact)

--- a/Facio/Extensions/Color+Theme.swift
+++ b/Facio/Extensions/Color+Theme.swift
@@ -84,39 +84,45 @@ extension Color {
     // Une seule opacité par rôle (remplace les 8 opacités de panneau divergentes).
     // En sombre : surfaces « surélevées » par un voile blanc (et non enfoncées),
     // sauf les champs de saisie qui restent creusés par un voile noir.
+    //
+    // ATTENTION : uniquement des constantes sRGB dans les branches — appeler
+    // `withAlphaComponent` sur une couleur de catalogue (controlBackgroundColor…)
+    // FIGE sa résolution à l'apparence active au moment de l'appel.
+    // En clair, controlBackgroundColor et textBackgroundColor valent blanc pur :
+    // les branches light reproduisent exactement le rendu d'avant.
 
     /// Fond des panneaux / cartes (SectionPanel).
     static var surfacePanel: Color {
         dynamic(
-            NSColor.controlBackgroundColor.withAlphaComponent(0.78),
+            NSColor.white.withAlphaComponent(0.78),
             NSColor.white.withAlphaComponent(0.055)
         )
     }
     /// Fond des tuiles métriques et tuiles d'action.
     static var surfaceTile: Color {
         dynamic(
-            NSColor.textBackgroundColor.withAlphaComponent(0.68),
+            NSColor.white.withAlphaComponent(0.68),
             NSColor.white.withAlphaComponent(0.075)
         )
     }
     /// Fond des lignes de liste au repos.
     static var surfaceRow: Color {
         dynamic(
-            NSColor.textBackgroundColor.withAlphaComponent(0.62),
+            NSColor.white.withAlphaComponent(0.62),
             NSColor.white.withAlphaComponent(0.06)
         )
     }
     /// Fond des lignes de liste au survol.
     static var surfaceRowHover: Color {
         dynamic(
-            NSColor.textBackgroundColor.withAlphaComponent(0.9),
+            NSColor.white.withAlphaComponent(0.9),
             NSColor.white.withAlphaComponent(0.11)
         )
     }
     /// Fond des champs de saisie / surfaces enfoncées.
     static var surfaceField: Color {
         dynamic(
-            NSColor.textBackgroundColor.withAlphaComponent(0.5),
+            NSColor.white.withAlphaComponent(0.5),
             NSColor.black.withAlphaComponent(0.22)
         )
     }

--- a/Facio/Extensions/Color+Theme.swift
+++ b/Facio/Extensions/Color+Theme.swift
@@ -4,17 +4,43 @@ extension Color {
     // MARK: - Couleurs principales de l'app
     // Note: static var au lieu de static let pour eviter un crash du compilateur Swift 6.0.x en release
 
-    /// Vert principal (barre de titre, en-tete tableau)
-    static var appPrimary: Color { Color(red: 0.33, green: 0.54, blue: 0.19) }
+    /// Adapte une couleur à l'apparence : `light` en clair, `dark` en sombre.
+    ///
+    /// Source unique du dark mode — les vues ne lisent JAMAIS `colorScheme`,
+    /// tout passe par les tokens de ce fichier. La closure se résout au dessin
+    /// et ne doit capturer que des NSColor immuables (Swift 6 : pas d'état
+    /// @MainActor ni de CompanyInfo dedans).
+    private static func dynamic(_ light: NSColor, _ dark: NSColor) -> Color {
+        Color(nsColor: NSColor(name: nil) { appearance in
+            appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua ? dark : light
+        })
+    }
+
+    /// Base sRGB du vert olive de marque (#6B8E3A approx.).
+    private static var oliveBase: NSColor {
+        NSColor(srgbRed: 0.33, green: 0.54, blue: 0.19, alpha: 1.0)
+    }
+
+    /// Vert principal (barre de titre, en-tete tableau) — éclairci en sombre
+    /// pour rester lisible en texte et en icône.
+    static var appPrimary: Color {
+        dynamic(oliveBase, oliveBase.lightened(by: 0.12))
+    }
 
     /// Vert clair pour les lignes alternees du tableau
-    static var appPrimaryLight: Color { Color(red: 0.33, green: 0.54, blue: 0.19).opacity(0.08) }
+    static var appPrimaryLight: Color {
+        dynamic(
+            oliveBase.withAlphaComponent(0.08),
+            oliveBase.lightened(by: 0.12).withAlphaComponent(0.14)
+        )
+    }
 
     /// Couleur principale dynamique (depuis CompanyInfo)
     static func appPrimary(from company: CompanyInfo) -> Color {
         guard let hex = company.couleurAccentHex,
               let ns = NSColor.fromHex(hex) else { return appPrimary }
-        return Color(nsColor: ns)
+        // Hex parsé AVANT la closure : elle ne capture que des NSColor immuables.
+        return dynamic(ns, ns.lightened(by: 0.12))
     }
 
     /// Fond de la sidebar
@@ -67,26 +93,61 @@ extension Color {
     // MARK: - Surfaces sémantiques
     //
     // Une seule opacité par rôle (remplace les 8 opacités de panneau divergentes).
+    // En sombre : surfaces « surélevées » par un voile blanc (et non enfoncées),
+    // sauf les champs de saisie qui restent creusés par un voile noir.
 
     /// Fond des panneaux / cartes (SectionPanel).
-    static var surfacePanel: Color { Color(nsColor: .controlBackgroundColor).opacity(0.78) }
+    static var surfacePanel: Color {
+        dynamic(
+            NSColor.controlBackgroundColor.withAlphaComponent(0.78),
+            NSColor.white.withAlphaComponent(0.055)
+        )
+    }
     /// Fond des tuiles métriques et tuiles d'action.
-    static var surfaceTile: Color { Color(nsColor: .textBackgroundColor).opacity(0.68) }
+    static var surfaceTile: Color {
+        dynamic(
+            NSColor.textBackgroundColor.withAlphaComponent(0.68),
+            NSColor.white.withAlphaComponent(0.075)
+        )
+    }
     /// Fond des lignes de liste au repos.
-    static var surfaceRow: Color { Color(nsColor: .textBackgroundColor).opacity(0.62) }
+    static var surfaceRow: Color {
+        dynamic(
+            NSColor.textBackgroundColor.withAlphaComponent(0.62),
+            NSColor.white.withAlphaComponent(0.06)
+        )
+    }
     /// Fond des lignes de liste au survol.
-    static var surfaceRowHover: Color { Color(nsColor: .textBackgroundColor).opacity(0.9) }
+    static var surfaceRowHover: Color {
+        dynamic(
+            NSColor.textBackgroundColor.withAlphaComponent(0.9),
+            NSColor.white.withAlphaComponent(0.11)
+        )
+    }
     /// Fond des champs de saisie / surfaces enfoncées.
-    static var surfaceField: Color { Color(nsColor: .textBackgroundColor).opacity(0.5) }
-    /// Fond de l'inspecteur latéral.
+    static var surfaceField: Color {
+        dynamic(
+            NSColor.textBackgroundColor.withAlphaComponent(0.5),
+            NSColor.black.withAlphaComponent(0.22)
+        )
+    }
+    /// Fond de l'inspecteur latéral (windowBackgroundColor est déjà dynamique).
     static var surfaceInspector: Color { Color(nsColor: .windowBackgroundColor) }
 
     // MARK: - Bordures sémantiques
+    //
+    // Renforcées en sombre : un voile primaire à 8 % y est presque invisible.
 
     /// Bordure discrète au repos (panneaux, tuiles, lignes).
-    static var borderSubtle: Color { Color.primary.opacity(0.08) }
+    static var borderSubtle: Color {
+        dynamic(NSColor.black.withAlphaComponent(0.08), NSColor.white.withAlphaComponent(0.12))
+    }
     /// Bordure au survol / focus.
-    static var borderHover: Color { Color.primary.opacity(0.14) }
+    static var borderHover: Color {
+        dynamic(NSColor.black.withAlphaComponent(0.14), NSColor.white.withAlphaComponent(0.20))
+    }
     /// Séparateur fin.
-    static var borderHairline: Color { Color.primary.opacity(0.06) }
+    static var borderHairline: Color {
+        dynamic(NSColor.black.withAlphaComponent(0.06), NSColor.white.withAlphaComponent(0.08))
+    }
 }

--- a/Facio/Extensions/Color+Theme.swift
+++ b/Facio/Extensions/Color+Theme.swift
@@ -27,14 +27,6 @@ extension Color {
         dynamic(oliveBase, oliveBase.lightened(by: 0.12))
     }
 
-    /// Vert clair pour les lignes alternees du tableau
-    static var appPrimaryLight: Color {
-        dynamic(
-            oliveBase.withAlphaComponent(0.08),
-            oliveBase.lightened(by: 0.12).withAlphaComponent(0.14)
-        )
-    }
-
     /// Couleur principale dynamique (depuis CompanyInfo)
     static func appPrimary(from company: CompanyInfo) -> Color {
         guard let hex = company.couleurAccentHex,
@@ -42,9 +34,6 @@ extension Color {
         // Hex parsé AVANT la closure : elle ne capture que des NSColor immuables.
         return dynamic(ns, ns.lightened(by: 0.12))
     }
-
-    /// Fond de la sidebar
-    static var sidebarBackground: Color { Color(nsColor: .controlBackgroundColor) }
 
     // MARK: - Palette d'intention (source de vérité unique)
     //

--- a/Facio/Extensions/NSColor+Hex.swift
+++ b/Facio/Extensions/NSColor+Hex.swift
@@ -31,4 +31,14 @@ extension NSColor {
                        blue: c.blueComponent * f,
                        alpha: c.alphaComponent)
     }
+
+    /// Lighter variant — moves RGB towards white by `factor` (miroir de `darkened(by:)`).
+    /// Utilisé pour l'accent de marque en mode sombre (lisibilité du texte/icônes).
+    func lightened(by factor: CGFloat = 0.15) -> NSColor {
+        guard let c = usingColorSpace(.sRGB) else { return self }
+        return NSColor(srgbRed: c.redComponent + (1.0 - c.redComponent) * factor,
+                       green: c.greenComponent + (1.0 - c.greenComponent) * factor,
+                       blue: c.blueComponent + (1.0 - c.blueComponent) * factor,
+                       alpha: c.alphaComponent)
+    }
 }


### PR DESCRIPTION
## Contexte

PR4 — dernière PR du chantier UI/UX (plan validé). L'app n'avait aucune gestion d'apparence (0 référence `colorScheme`) : le dark mode « marchait » mécaniquement via les NSColor système mais n'avait jamais été maîtrisé.

## Approche

Un helper privé `dynamic(light:dark:)` (NSColor `dynamicProvider`, résolu au dessin) **dans `Color+Theme.swift` uniquement** — les vues continuent de ne jamais lire `colorScheme`, tout passe par les tokens. **Le mode clair reste strictement identique** (vérifié token par token par la revue : équivalences `opacity`/`withAlphaComponent`, colorspace sRGB, `Color.primary` = noir en clair).

## Variantes sombres

- **Surfaces « surélevées »** par un voile blanc (panneaux 5,5 %, tuiles 7,5 %, lignes 6 %, survol 11 %) au lieu de s'enfoncer ; **champs creusés** (noir 22 %) ; inspecteur inchangé (déjà dynamique).
- **Bordures renforcées** (8→12 %, 14→20 %, 6→8 %) — un voile à 8 % était quasi invisible sur fond sombre.
- **Accent de marque éclairci de 12 %** en sombre (lisibilité en texte/icône), y compris l'accent personnalisé de CompanyInfo (hex parsé hors closure — contrainte Swift 6). Nouveau `lightened(by:)` dans `NSColor+Hex`, miroir de `darkened(by:)`.
- Le **PDF n'est pas affecté** (il utilise la couleur de marque brute + `darkened`, fond blanc quel que soit le mode) ; `bestMatch` gère les variantes high-contrast.
- Nettoyage : `appPrimaryLight` et `sidebarBackground` (tokens morts, zéro usage) supprimés.

## Vérification

- `swift build` 0 erreur 0 warning · `--run-regressions` **80/80**.
- Revue sceptique : 6/6 points vérifiés (iso-light, colorspace, récursion provider, high-contrast, PDF, usages morts).
- **À l'œil avant merge (c'est le cœur de cette PR)** : basculer Réglages Système > Apparence en laissant l'app ouverte (les couleurs se re-résolvent sans relancer) et passer chaque écran en sombre — Dashboard, liste + éditeur de documents, clients, heures, planning, les 9 onglets Réglages, ⌘K, états vides. Les opacités sombres sont des points de départ raisonnables : si un écran te semble terne ou trop contrasté, dis-le-moi, l'ajustement se fait en un point (`Color+Theme`).