### PR TITLE
feat(justificatifs): aperçu intégré, report en ligne, TVA par ligne

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,17 +5,22 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Build & Run
 
 ```bash
-swift build                    # Debug build
-swift run                      # Build + run the app
+swift build                          # Debug build
+swift run                            # Build + run the app
+swift run Facio --run-regressions    # Run the compiled-in regression suite
 CODESIGN_IDENTITY="Developer ID Application: Your Name (TEAMID)" ./scripts/build-app.sh 1.0.0
 ALLOW_AD_HOC_SIGNING=1 ./scripts/build-app.sh 1.0.0  # Local-only unsigned distribution build
 ```
 
-No test suite is configured. No linter is configured.
+No linter is configured. There is no SPM test target; instead, regression tests live in `Facio/Diagnostics/RegressionSuite.swift`, compiled only in debug builds (`FACIO_REGRESSION_TESTS` define in Package.swift) and triggered by the `--run-regressions` flag. To add a test, append a `RegressionCase` to the `cases` array — the suite always runs all cases. CI (`.github/workflows/ci.yml`) runs build + regression suite + a packaging smoke test on every PR and push to main.
+
+### Supabase secrets
+
+`Facio/Config/Secrets.swift` resolves `SUPABASE_URL` / `SUPABASE_ANON_KEY` from `SecretsGenerated.swift` (injected at CI build time) with a fallback to a `.env` file at the project root for local dev. Without either, sync is simply unconfigured — the app still runs.
 
 ## Architecture
 
-macOS SwiftUI app (Swift 6.0, macOS 15+) built with Swift Package Manager. Generates professional invoices (factures) and quotes (devis) as PDF, with multi-currency support (EUR, USD, USDC, USDT, BTC, ETH) and blockchain payment tracking. Includes a timesheet system for tracking weekly hours.
+macOS SwiftUI app (Swift 6.0, macOS 15+) built with Swift Package Manager. Generates professional invoices (factures) and quotes (devis) as PDF, with multi-currency support (EUR, USD, USDC, USDT, BTC, ETH), blockchain payment tracking (Solana Pay via the SolKit dependency), time tracking (timesheets + timer + TimeHub aggregation), and a revenue dashboard.
 
 ### Data Flow
 
@@ -29,29 +34,44 @@ macOS SwiftUI app (Swift 6.0, macOS 15+) built with Swift Package Manager. Gener
 - **Safe array access pattern** — all `ForEach` + `Binding` combos access items by UUID lookup (`first(where: { $0.id == id })`), never by captured index. This prevents crashes when items are deleted while SwiftUI still holds stale Bindings.
 - **PaymentMode enum** — documents have a `paymentMode` (aucun/virement/crypto) independent of currency. "Aucun" hides all payment info from both UI and PDF.
 - **DesignationPreset** — favorite line items stored in CompanyInfo, insertable with one click in the editor.
-- **Offline-first sync** — local JSON is always the source of truth. SyncService pushes to Supabase via REST (UPSERT). Anonymous auth via Keychain-stored tokens.
-- **Timesheet hours conversion** — input `6.30` (6h30min) is auto-converted to `6.5` decimal hours. Minutes part (after dot) is divided by 60.
+- **Offline-first sync** — local JSON is always the source of truth. SyncService pushes to Supabase via REST (UPSERT). Anonymous auth via Keychain-stored tokens. Document attachments stay local (not synced).
+- **Timesheet hours conversion** — input `6.30` (6h30min) is auto-converted to `6.5` decimal hours. Minutes part (after dot) is divided by 60. Parsing lives in `TimesheetHourInputParser` and is covered by regression tests.
+
+### Design System (Views/Components/)
+
+All UI chrome is tokenized — no magic values in views:
+
+- **`FacioLayout`** (`DesignSystem.swift`) — spacing (4 pt grid), named radii, field/column widths, window minimums (960×640), and responsive breakpoints.
+- **`FacioFont`** (`FacioTypography.swift`) — typography tokens.
+- **Colors** (`Extensions/Color+Theme.swift`) — single source of truth for dark mode: views NEVER read `colorScheme`; every color goes through dynamic tokens built with `dynamic(light, dark)`. Semantic statuses use the intent palette (`intentSuccess`, `intentWarning`, `intentDanger`, `intentInfo`) — never raw `.green`/`.orange`/`.red`.
+- **`FacioMotion`** — closed animation vocabulary (`hover`, `state`, `emphasis` + `slideIn`/`slideUp` transitions). No bare `.animation()` or magic durations; always bind to a `value:`, and respect reduce-motion via `FacioMotion.respecting(_:reduceMotion:)`.
+- **Controls** — text fields get chrome via `.facioField(error:density:)` on native `TextField`s; buttons use `.buttonStyle(.facio(.primary))` (roles: primary/secondary/etc.).
+- **Toasts** — `ToastCenter` (`@Observable`, in environment): `toastCenter.show(message, tone:)`.
+- **Responsive layout** (`ResponsiveLayout.swift`) — views read `@Environment(\.facioWidthClass)` (compact/regular/wide, derived from `FacioLayout` breakpoints) instead of measuring geometry themselves.
 
 ### Module Layout
 
-- `Models/` — Document, LineItem, ClientInfo, CompanyInfo, Currency, Blockchain, Enums, TransactionSignature, Timesheet. All are Codable.
-- `Services/DataStore.swift` — JSON persistence, CRUD operations, per-key save methods
+- `Models/` — Document, LineItem, ClientInfo, CompanyInfo, Currency, Blockchain, Enums, TransactionSignature, DocumentAttachment, Timesheet/TimesheetWeek/TimesheetDay, TimeEntry. All are Codable.
+- `Services/DataStore.swift` — JSON persistence, CRUD operations, per-key save methods, corrupt-file quarantine
 - `Services/SyncService.swift` — Supabase REST sync (UPSERT/pull), dirty tracking, sync state
 - `Services/AuthService.swift` — Supabase anonymous + email auth, Keychain token storage
-- `Services/NetworkMonitor.swift` — NWPathMonitor wrapper for connectivity detection
 - `Services/DocumentNumberService.swift` — auto-numbering: `Facture_2026_03` / `Invoice_2026_03`
-- `Services/ExportService.swift` — NSSavePanel wrapper for PDF export
-- `Views/ContentView.swift` — three-column NavigationSplitView (sidebar → list → detail)
-- `Views/Documents/DocumentEditorView.swift` — main editor with all sections
-- `Views/Timesheet/` — TimesheetListView, TimesheetEditorView for weekly hour tracking
-- `Views/Settings/` — Company, Payment, Defaults, Prestations, Language, Sync, About
+- `Services/` (other) — ExportService (NSSavePanel PDF export), EmailService, SolanaPayService, AccountingRevenueService (multi-currency revenue conversion), TimeTrackingService + TimeHubAggregationService + TimesheetInvoiceService (timer → timesheet → invoice flow), UpdateService, NetworkMonitor, KeychainService/SecurePersistence
+- `Views/ContentView.swift` — three-column NavigationSplitView (sidebar → list → detail) + command palette (`CommandPaletteView`)
+- `Views/Sidebar/` — sections: factures, devis, clients, heures, planning, dashboard, parametres
+- `Views/Documents/DocumentEditorView.swift` — main editor, with sections split into sibling files (line items, payment info, signatures, attachments)
+- `Views/TimeHub/`, `Views/Timesheet/` — time tracking UI (timer panel, weekly timesheets, aggregation hub)
+- `Views/Dashboard/DashboardView.swift` — revenue/KPI dashboard
+- `Views/Settings/` — Company, Payment, Defaults, Prestations, Customisation, Email, Language, Sync, About
 - `PDF/PDFGenerator.swift` — full A4 PDF rendering. Olive green theme (#6B8E3A). Abstract circle logo fallback.
 - `PDF/PDFLayout.swift` — all constants (fonts, colors, margins, column widths)
-- `Extensions/` — Date and Decimal French formatting helpers, Color theme
+- `Extensions/` — Date and Decimal French formatting helpers, Color theme, NSColor hex
+- `Config/` — Supabase secrets resolution
+- `Diagnostics/RegressionSuite.swift` — debug-only regression tests
 
 ### Internationalization (i18n)
 
-The app supports **French** (default) and **English**. All user-facing strings are centralized in `Localization/L10n.swift`.
+The app supports **French** (default) and **English**. All user-facing strings are centralized in `Localization/` — `L10n.swift` plus per-domain extensions (`L10n+Documents.swift`, `L10n+Settings.swift`, etc.).
 
 - **Language per document** — each `Document` has a `langue` field (FR/EN). The PDF and document number (`Facture_` vs `Invoice_`) adapt to the document's language.
 - **Global UI language** — controlled by `CompanyInfo.langueParDefaut`. All views use `private var lang: AppLanguage { dataStore.companyInfo.langueParDefaut }` to access it.
@@ -81,3 +101,5 @@ When adding a field to Document or CompanyInfo:
 2. Add to `CodingKeys` enum
 3. In `init(from decoder:)`, use `(try? container.decode(...)) ?? defaultValue` for backwards compatibility
 4. Add to `encode(to:)`
+
+When changing Codable fields or persistence, add a regression case covering old-payload decoding (see existing cases like "document decodes old payloads without accounting conversion").

--- a/Facio/Localization/L10n+Documents.swift
+++ b/Facio/Localization/L10n+Documents.swift
@@ -48,6 +48,7 @@ extension L10n {
         return l == .fr ? "\(value) %" : "\(value)%"
     }
     static func totalHTLabel(_ l: AppLanguage) -> String { l == .fr ? "Total HT" : "Subtotal" }
+    static func totalTTCLabel(_ l: AppLanguage) -> String { l == .fr ? "Total TTC" : "Total" }
     static func priceLabel(_ l: AppLanguage) -> String { l == .fr ? "Prix" : "Price" }
     static func qtyShort(_ l: AppLanguage) -> String { l == .fr ? "Qte" : "Qty" }
     static func noLines(_ l: AppLanguage) -> String { l == .fr ? "Aucune ligne. Ajoutez-en une ci-dessous." : "No line items. Add one below." }

--- a/Facio/Localization/L10n+Email.swift
+++ b/Facio/Localization/L10n+Email.swift
@@ -13,6 +13,19 @@ extension L10n {
     static func dropAttachmentHere(_ l: AppLanguage) -> String { l == .fr ? "Déposez vos fichiers ici" : "Drop your files here" }
     static func attachmentLabelPlaceholder(_ l: AppLanguage) -> String { l == .fr ? "Libellé (ex. Train Nancy⇄Paris)" : "Label (e.g. Train Nancy⇄Paris)" }
     static func openAttachment(_ l: AppLanguage) -> String { l == .fr ? "Ouvrir" : "Open" }
+    static func openAttachmentExternally(_ l: AppLanguage) -> String { l == .fr ? "Ouvrir dans l'app externe" : "Open in external app" }
+    static func attachmentPreviewUnavailable(_ l: AppLanguage) -> String { l == .fr ? "Aperçu indisponible" : "Preview unavailable" }
+    static func attachmentPreviewUnavailableHint(_ l: AppLanguage) -> String {
+        l == .fr ? "Ce fichier ne peut pas être affiché ici. Ouvrez-le dans l'app externe."
+        : "This file cannot be displayed here. Open it in the external app."
+    }
+
+    // Montant reportable d'un justificatif
+    static func attachmentAmount(_ l: AppLanguage) -> String { l == .fr ? "Montant" : "Amount" }
+    static func attachmentAmountHT(_ l: AppLanguage) -> String { l == .fr ? "HT" : "Excl. tax" }
+    static func attachmentAmountTTC(_ l: AppLanguage) -> String { l == .fr ? "TTC" : "Incl. tax" }
+    static func reportToInvoice(_ l: AppLanguage) -> String { l == .fr ? "Reporter sur la facture" : "Add to invoice" }
+    static func toastLineReported(_ l: AppLanguage) -> String { l == .fr ? "Ligne ajoutée à la facture" : "Line added to invoice" }
     static func attachmentImportFailedCount(_ l: AppLanguage, count: Int) -> String {
         if l == .fr {
             return count == 1

--- a/Facio/Models/DocumentAttachment.swift
+++ b/Facio/Models/DocumentAttachment.swift
@@ -16,6 +16,13 @@ struct DocumentAttachment: Identifiable, Codable, Hashable {
     /// Taille en octets (pour affichage).
     var fileSize: Int = 0
     var addedAt: Date = Date()
+    /// Montant du justificatif, reportable en ligne de facture. `0` = non renseigné.
+    var montant: Decimal = 0
+    /// Taux de TVA (%) appliqué au report.
+    var tauxTVA: Decimal = 0
+    /// `true` si `montant` est saisi TTC (on calcule le HT à rebours au report),
+    /// `false` s'il est saisi HT (utilisé tel quel comme prix unitaire).
+    var montantEstTTC: Bool = false
 
     init(
         id: UUID = UUID(),
@@ -23,7 +30,10 @@ struct DocumentAttachment: Identifiable, Codable, Hashable {
         fileExtension: String = "",
         label: String = "",
         fileSize: Int = 0,
-        addedAt: Date = Date()
+        addedAt: Date = Date(),
+        montant: Decimal = 0,
+        tauxTVA: Decimal = 0,
+        montantEstTTC: Bool = false
     ) {
         self.id = id
         self.originalFilename = originalFilename
@@ -31,6 +41,9 @@ struct DocumentAttachment: Identifiable, Codable, Hashable {
         self.label = label
         self.fileSize = fileSize
         self.addedAt = addedAt
+        self.montant = montant
+        self.tauxTVA = tauxTVA
+        self.montantEstTTC = montantEstTTC
     }
 
     init(from decoder: Decoder) throws {
@@ -41,10 +54,20 @@ struct DocumentAttachment: Identifiable, Codable, Hashable {
         label = try container.decodeOrDefault(String.self, forKey: .label, default: "")
         fileSize = try container.decodeOrDefault(Int.self, forKey: .fileSize, default: 0)
         addedAt = try container.decodeOrDefault(Date.self, forKey: .addedAt, default: Date())
+        montant = try container.decodeOrDefault(Decimal.self, forKey: .montant, default: 0)
+        tauxTVA = try container.decodeOrDefault(Decimal.self, forKey: .tauxTVA, default: 0)
+        montantEstTTC = try container.decodeOrDefault(Bool.self, forKey: .montantEstTTC, default: false)
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id, originalFilename, fileExtension, label, fileSize, addedAt
+        case id, originalFilename, fileExtension, label, fileSize, addedAt, montant, tauxTVA, montantEstTTC
+    }
+
+    /// Montant HT effectif pour un report en ligne de facture.
+    var montantHT: Decimal {
+        guard montantEstTTC else { return montant }
+        let diviseur = 1 + tauxTVA / 100
+        return diviseur == 0 ? montant : montant / diviseur
     }
 
     /// Nom du fichier tel que stocké sur disque.

--- a/Facio/Services/DataStore.swift
+++ b/Facio/Services/DataStore.swift
@@ -497,6 +497,14 @@ final class DataStore: Sendable {
         saveDocuments()
     }
 
+    /// Remplace les métadonnées d'un justificatif (montant, TVA, mode HT/TTC…) et sauvegarde.
+    func updateAttachment(_ attachment: DocumentAttachment, in document: Document) {
+        guard let index = document.attachments.firstIndex(where: { $0.id == attachment.id }) else { return }
+        document.attachments[index] = attachment
+        document.updatedAt = Date()
+        saveDocuments()
+    }
+
     /// Supprime un justificatif (fichier + métadonnée) et sauvegarde.
     func deleteAttachment(_ attachment: DocumentAttachment, from document: Document) {
         try? fileManager.removeItem(at: attachmentURL(attachment, in: document))

--- a/Facio/Views/Components/DesignSystem.swift
+++ b/Facio/Views/Components/DesignSystem.swift
@@ -88,7 +88,8 @@ enum FacioLayout {
     /// Largeur minimale d'un champ dans une `FormGrid`.
     static let fieldMinWidth: CGFloat = 150
     /// Largeur de conteneur sous laquelle le tableau de lignes passe en mode compact.
-    static let lineItemsCompactBreakpoint: CGFloat = 700
+    /// (Relevé pour absorber la colonne « Total TTC » sans rogner la désignation.)
+    static let lineItemsCompactBreakpoint: CGFloat = 820
     /// Cap de largeur du panneau de totaux (pleine largeur en compact).
     static let totalsMaxWidth: CGFloat = 350
 

--- a/Facio/Views/ContentView.swift
+++ b/Facio/Views/ContentView.swift
@@ -89,27 +89,32 @@ struct ContentView: View {
         }
         .toolbar {
             ToolbarItemGroup(placement: .primaryAction) {
-                Menu {
-                    Button {
-                        newDocument(.facture)
+                // Masqué sur « Heures & facturation » : sur cette page on fait un
+                // relevé d'heures (« Nouvelle période »), pas une facture — le menu
+                // « Nouveau » global y prêtait à confusion.
+                if selectedSection != .heures {
+                    Menu {
+                        Button {
+                            newDocument(.facture)
+                        } label: {
+                            Label(L10n.quickCreateInvoice(lang), systemImage: SidebarSection.factures.icon)
+                        }
+                        Button {
+                            newDocument(.devis)
+                        } label: {
+                            Label(L10n.quickCreateQuote(lang), systemImage: SidebarSection.devis.icon)
+                        }
+                        Divider()
+                        Button {
+                            newClient()
+                        } label: {
+                            Label(L10n.quickCreateClient(lang), systemImage: "person.crop.circle.badge.plus")
+                        }
                     } label: {
-                        Label(L10n.quickCreateInvoice(lang), systemImage: SidebarSection.factures.icon)
+                        Label(L10n.new(lang), systemImage: "plus")
                     }
-                    Button {
-                        newDocument(.devis)
-                    } label: {
-                        Label(L10n.quickCreateQuote(lang), systemImage: SidebarSection.devis.icon)
-                    }
-                    Divider()
-                    Button {
-                        newClient()
-                    } label: {
-                        Label(L10n.quickCreateClient(lang), systemImage: "person.crop.circle.badge.plus")
-                    }
-                } label: {
-                    Label(L10n.new(lang), systemImage: "plus")
+                    .help(L10n.new(lang))
                 }
-                .help(L10n.new(lang))
 
                 Button {
                     showCommandPalette = true

--- a/Facio/Views/Documents/AttachmentPreviewSheet.swift
+++ b/Facio/Views/Documents/AttachmentPreviewSheet.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+import AppKit
+
+/// Aperçu intégré d'un justificatif (PDF ou image) — évite d'ouvrir le
+/// navigateur / une app externe. Le PDF réutilise `PDFPreviewView` ; les images
+/// sont affichées via `NSImage`. Bouton d'ouverture externe conservé en repli.
+struct AttachmentPreviewSheet: View {
+    let url: URL
+    let attachment: DocumentAttachment
+    let lang: AppLanguage
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text(attachment.displayName)
+                    .font(.headline)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer()
+                Button(L10n.openAttachmentExternally(lang)) {
+                    NSWorkspace.shared.open(url)
+                }
+                Button(L10n.close(lang)) {
+                    dismiss()
+                }
+                .keyboardShortcut(.escape)
+            }
+            .padding()
+
+            Divider()
+
+            content
+        }
+        .frame(minWidth: FacioLayout.sheetMinWidth, minHeight: 420)
+        .presentationSizing(.page)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if attachment.isPDF, let data = try? Data(contentsOf: url) {
+            PDFPreviewView(data: data)
+        } else if attachment.isImage, let image = NSImage(contentsOf: url) {
+            ScrollView([.horizontal, .vertical]) {
+                Image(nsImage: image)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .padding(FacioLayout.space16)
+            }
+        } else {
+            ContentUnavailableView {
+                Label(L10n.attachmentPreviewUnavailable(lang), systemImage: "eye.slash")
+            } description: {
+                Text(L10n.attachmentPreviewUnavailableHint(lang))
+            } actions: {
+                Button(L10n.openAttachmentExternally(lang)) {
+                    NSWorkspace.shared.open(url)
+                }
+            }
+        }
+    }
+}

--- a/Facio/Views/Documents/DocumentAttachmentsSection.swift
+++ b/Facio/Views/Documents/DocumentAttachmentsSection.swift
@@ -15,6 +15,7 @@ struct DocumentAttachmentsSection: View {
     @State private var dropAddedCount = 0
     @State private var dropToastTask: Task<Void, Never>?
     @State private var attachmentPendingDeletion: DocumentAttachment?
+    @State private var attachmentToPreview: DocumentAttachment?
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(ToastCenter.self) private var toastCenter
 
@@ -33,7 +34,7 @@ struct DocumentAttachmentsSection: View {
                                 document: document,
                                 attachment: attachment,
                                 lang: lang,
-                                onOpen: { open(attachment) },
+                                onOpen: { attachmentToPreview = attachment },
                                 onDelete: { attachmentPendingDeletion = attachment }
                             )
                             if attachment.id != document.attachments.last?.id {
@@ -81,6 +82,13 @@ struct DocumentAttachmentsSection: View {
                 name: attachmentPendingDeletion?.originalFilename ?? ""
             ))
         }
+        .sheet(item: $attachmentToPreview) { attachment in
+            AttachmentPreviewSheet(
+                url: dataStore.attachmentURL(attachment, in: document),
+                attachment: attachment,
+                lang: lang
+            )
+        }
     }
 
     private var dropZone: some View {
@@ -106,10 +114,6 @@ struct DocumentAttachmentsSection: View {
         .onDrop(of: [.fileURL], isTargeted: $isDropTargeted) { providers in
             handleDrop(providers)
         }
-    }
-
-    private func open(_ attachment: DocumentAttachment) {
-        NSWorkspace.shared.open(dataStore.attachmentURL(attachment, in: document))
     }
 
     /// Types acceptés (cohérents entre sélecteur de fichiers et glisser-déposer).
@@ -183,16 +187,24 @@ private struct AttachmentRowView: View {
     let onDelete: () -> Void
 
     @Environment(DataStore.self) private var dataStore
+    @Environment(ToastCenter.self) private var toastCenter
     @State private var labelText: String = ""
     @FocusState private var labelFocused: Bool
 
-    var body: some View {
-        HStack(spacing: FacioLayout.space10) {
-            Image(systemName: attachment.iconName)
-                .foregroundStyle(Color.appPrimary(from: dataStore.companyInfo))
-                .frame(width: 24)
+    private static let tvaRates: [Decimal] = [0, 5.5, 10, 20]
 
-            VStack(alignment: .leading, spacing: FacioLayout.space2) {
+    private var numberFormat: AppLanguage { dataStore.companyInfo.formatNombre }
+    /// Décalage pour aligner les rangées sous le libellé (icône + espacement).
+    private var contentInset: CGFloat { 24 + FacioLayout.space10 }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: FacioLayout.space6) {
+            // Niveau 1 : icône + libellé (= nom) + ouvrir / supprimer.
+            HStack(spacing: FacioLayout.space10) {
+                Image(systemName: attachment.iconName)
+                    .foregroundStyle(Color.appPrimary(from: dataStore.companyInfo))
+                    .frame(width: 24)
+
                 TextField(L10n.attachmentLabelPlaceholder(lang), text: $labelText)
                     .textFieldStyle(.plain)
                     .font(FacioFont.rowTitle)
@@ -202,25 +214,74 @@ private struct AttachmentRowView: View {
                         if !focused { commitLabel() }
                     }
 
-                HStack(spacing: FacioLayout.space6) {
-                    Text(attachment.originalFilename)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                    Text("•")
-                    Text(attachment.formattedSize)
+                Spacer()
+
+                FacioIconButton(systemImage: "arrow.up.right.square", help: L10n.openAttachment(lang)) {
+                    onOpen()
                 }
-                .font(FacioFont.captionSmall)
-                .foregroundStyle(.secondary)
+                FacioIconButton(systemImage: "trash", tone: .intentDanger, help: L10n.delete(lang)) {
+                    onDelete()
+                }
             }
 
-            Spacer()
+            // Niveau 2 : montant (HT/TTC) + TVA + report en ligne de facture.
+            HStack(spacing: FacioLayout.space8) {
+                DecimalField(
+                    placeholder: L10n.attachmentAmount(lang),
+                    value: Binding(
+                        get: { attachment.montant },
+                        set: { newVal in update { $0.montant = newVal } }
+                    ),
+                    maximumFractionDigits: document.currency.maximumFractionDigits
+                )
+                .format(numberFormat)
+                .frame(width: 110)
 
-            FacioIconButton(systemImage: "arrow.up.right.square", help: L10n.openAttachment(lang)) {
-                onOpen()
+                Picker("", selection: Binding(
+                    get: { attachment.montantEstTTC },
+                    set: { newVal in update { $0.montantEstTTC = newVal } }
+                )) {
+                    Text(L10n.attachmentAmountHT(lang)).tag(false)
+                    Text(L10n.attachmentAmountTTC(lang)).tag(true)
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .frame(width: 120)
+
+                Picker(L10n.vatLabel(lang), selection: Binding(
+                    get: { attachment.tauxTVA },
+                    set: { newVal in update { $0.tauxTVA = newVal } }
+                )) {
+                    ForEach(Self.tvaRates, id: \.self) { rate in
+                        Text(L10n.vatRateLabel(numberFormat, rate: rate)).tag(rate)
+                    }
+                }
+                .labelsHidden()
+                .frame(width: 90)
+
+                Button {
+                    report()
+                } label: {
+                    Label(L10n.reportToInvoice(lang), systemImage: "arrow.right.doc.on.clipboard")
+                }
+                .buttonStyle(.borderless)
+                .disabled(attachment.montant <= 0)
+
+                Spacer()
             }
-            FacioIconButton(systemImage: "trash", tone: .intentDanger, help: L10n.delete(lang)) {
-                onDelete()
+            .padding(.leading, contentInset)
+
+            // Méta : nom de fichier d'origine + taille.
+            HStack(spacing: FacioLayout.space6) {
+                Text(attachment.originalFilename)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Text("•")
+                Text(attachment.formattedSize)
             }
+            .font(FacioFont.captionSmall)
+            .foregroundStyle(.secondary)
+            .padding(.leading, contentInset)
         }
         .padding(.vertical, FacioLayout.space4)
         .onAppear { labelText = attachment.label }
@@ -232,5 +293,26 @@ private struct AttachmentRowView: View {
     private func commitLabel() {
         guard labelText != attachment.label else { return }
         dataStore.updateAttachmentLabel(attachment, label: labelText, in: document)
+    }
+
+    /// Applique une mutation sur une copie du justificatif et la persiste.
+    private func update(_ mutate: (inout DocumentAttachment) -> Void) {
+        var copy = attachment
+        mutate(&copy)
+        dataStore.updateAttachment(copy, in: document)
+    }
+
+    /// Crée une ligne de facture à partir du justificatif (montant ramené en HT).
+    private func report() {
+        let ligne = LineItem(
+            designation: attachment.displayName,
+            quantite: 1,
+            prixUnitaire: attachment.montantHT,
+            tauxTVA: attachment.tauxTVA,
+            ordre: document.lignes.count
+        )
+        document.ajouterLigne(ligne)
+        dataStore.documentUpdated(document)
+        toastCenter.show(L10n.toastLineReported(lang), icon: "list.bullet.rectangle")
     }
 }

--- a/Facio/Views/Documents/DocumentLineItemsSection.swift
+++ b/Facio/Views/Documents/DocumentLineItemsSection.swift
@@ -7,6 +7,7 @@ enum LineItemColumns {
     static let unitPrice: CGFloat = 110
     static let vat: CGFloat = 80
     static let totalHT: CGFloat = 110
+    static let totalTTC: CGFloat = 110
     static let actions: CGFloat = 32
 
     // Variante compacte (ligne sur deux niveaux, sous
@@ -56,6 +57,8 @@ struct DocumentLineItemsSection: View {
                 .frame(width: LineItemColumns.vat, alignment: .center)
             Text(L10n.totalHTLabel(lang))
                 .frame(width: LineItemColumns.totalHT, alignment: .trailing)
+            Text(L10n.totalTTCLabel(lang))
+                .frame(width: LineItemColumns.totalTTC, alignment: .trailing)
             Spacer().frame(width: LineItemColumns.actions)
         }
         .font(.caption)

--- a/Facio/Views/Documents/LineItemRowView.swift
+++ b/Facio/Views/Documents/LineItemRowView.swift
@@ -61,6 +61,8 @@ struct LineItemRowView: View {
                 .frame(width: LineItemColumns.vat)
             totalText(for: currentLigne)
                 .frame(width: LineItemColumns.totalHT, alignment: .trailing)
+            totalTTCText(for: currentLigne)
+                .frame(width: LineItemColumns.totalTTC, alignment: .trailing)
             actionsMenu
         }
     }
@@ -81,7 +83,12 @@ struct LineItemRowView: View {
                 vatPicker
                     .frame(width: LineItemColumns.compactVat)
                 Spacer()
-                totalText(for: currentLigne)
+                VStack(alignment: .trailing, spacing: FacioLayout.space2) {
+                    Text(document.currency.formatAccounting(currentLigne.totalLigne, lang: numberFormat))
+                        .font(FacioFont.caption)
+                        .foregroundStyle(.secondary)
+                    totalTTCText(for: currentLigne)
+                }
             }
         }
     }
@@ -144,9 +151,15 @@ struct LineItemRowView: View {
         .labelsHidden()
     }
 
-    /// Total (lecture seule)
+    /// Total HT (lecture seule)
     private func totalText(for line: LineItem) -> some View {
         Text(document.currency.formatAccounting(line.totalLigne, lang: numberFormat))
+            .font(FacioFont.amount)
+    }
+
+    /// Total TTC de la ligne (HT + TVA), lecture seule.
+    private func totalTTCText(for line: LineItem) -> some View {
+        Text(document.currency.formatAccounting(line.totalTTC, lang: numberFormat))
             .font(FacioFont.amount)
     }
 


### PR DESCRIPTION
## Résumé

Quatre améliorations remontées à l'usage.

### 1. Justificatifs ouverts dans Facio
Aperçu PDF/image intégré (`AttachmentPreviewSheet`) au lieu d'ouvrir le navigateur. Ouverture externe conservée en repli.

### 2. Justificatif → ligne de facture
Champs **nom / montant / TVA** + toggle **HT/TTC** par justificatif, et bouton **« Reporter »** qui crée une ligne de facture (montant ramené en HT au report). Une fois reportée c'est une ligne normale : supprimable.

### 3. Colonne Total TTC par ligne
Total TTC affiché à côté du Total HT dans le tableau des lignes (ex. 200 € + 10 % → 220 €), pas seulement dans le total final.

### 4. Menu « Nouveau » masqué sur « Heures & facturation »
Sur cette page on fait un relevé d'heures : le menu global « Nouveau » prêtait à confusion. La « Nouvelle période » et la palette de commandes restent.

## Tests
- `swift build` ✅
- `swift run Facio --run-regressions` → 81/81 ✅ (dont décodage rétro-compatible des anciens `documents.json`)
- Chaînes FR + EN via `L10n`