### PR TITLE
fix(email): nommer les pièces jointes d'après leur libellé

### DIFF
--- a/Facio/Diagnostics/RegressionSuite.swift
+++ b/Facio/Diagnostics/RegressionSuite.swift
@@ -117,6 +117,7 @@ enum FacioRegressionSuite {
         RegressionCase(name: "attachment import copies file and records metadata", run: attachmentImportCopiesFileAndRecordsMetadata),
         RegressionCase(name: "attachment duplication reports missing source files", run: attachmentDuplicationReportsMissingSourceFiles),
         RegressionCase(name: "attachment urls expose only existing files", run: attachmentURLsExposeOnlyExistingFiles),
+        RegressionCase(name: "email attachment filenames use labels and dedupe", run: emailAttachmentFilenamesUseLabelsAndDedupe),
         RegressionCase(name: "pdf generation paginates long invoices", run: pdfGenerationPaginatesLongInvoices),
         RegressionCase(name: "responsive width class maps breakpoints", run: responsiveWidthClassMapsBreakpoints),
         RegressionCase(name: "window minimum fits split view columns", run: windowMinimumFitsSplitViewColumns),
@@ -2036,6 +2037,20 @@ enum FacioRegressionSuite {
             try expectEqual(urls.first, store.attachmentURL(stays, in: document))
             try expectEqual(document.attachments.count, 2)
         }
+    }
+
+    private static func emailAttachmentFilenamesUseLabelsAndDedupe() throws {
+        let url = URL(fileURLWithPath: "/tmp/x")
+        let attachments = [
+            // Libellé renseigné → nom = libellé + extension.
+            EmailService.EmailAttachment(sourceURL: url, displayName: "Train Nancy-Paris", fileExtension: "pdf"),
+            // Sans libellé : displayName retombe sur le nom d'origine.
+            EmailService.EmailAttachment(sourceURL: url, displayName: "recu.jpg", fileExtension: "jpg"),
+            // Même libellé qu'un précédent → dédoublonné en `-2`.
+            EmailService.EmailAttachment(sourceURL: url, displayName: "Train Nancy-Paris", fileExtension: "pdf"),
+        ]
+        let names = EmailService.uniqueFilenames(for: attachments)
+        try expectEqual(names, ["Train Nancy-Paris.pdf", "recu.jpg", "Train Nancy-Paris-2.pdf"])
     }
 
     private static func withTemporaryDataStore(_ body: (DataStore) throws -> Void) throws {

--- a/Facio/Services/DataStore.swift
+++ b/Facio/Services/DataStore.swift
@@ -460,6 +460,20 @@ final class DataStore: Sendable {
             .filter { fileManager.fileExists(atPath: $0.path) }
     }
 
+    /// Justificatifs existants d'un document, prêts pour l'email : URL source +
+    /// nom lisible (libellé sinon nom d'origine) pour renommer la pièce jointe.
+    func emailAttachments(for document: Document) -> [EmailService.EmailAttachment] {
+        document.attachments.compactMap { attachment in
+            let url = attachmentURL(attachment, in: document)
+            guard fileManager.fileExists(atPath: url.path) else { return nil }
+            return EmailService.EmailAttachment(
+                sourceURL: url,
+                displayName: attachment.displayName,
+                fileExtension: attachment.fileExtension
+            )
+        }
+    }
+
     /// Importe un fichier comme justificatif : copie sur disque, ajoute la
     /// métadonnée au document et sauvegarde. Retourne nil en cas d'échec.
     @discardableResult

--- a/Facio/Services/EmailService.swift
+++ b/Facio/Services/EmailService.swift
@@ -9,6 +9,14 @@ enum EmailService {
         case unavailable
     }
 
+    /// Un justificatif à joindre : fichier source sur disque + nom lisible désiré
+    /// (libellé ou nom d'origine), l'extension étant conservée à la copie.
+    struct EmailAttachment {
+        let sourceURL: URL
+        let displayName: String
+        let fileExtension: String
+    }
+
     /// Substitue les variables d'un modèle d'email avec les données du document.
     static func resolveTemplate(_ template: String, document: Document, company: CompanyInfo) -> String {
         let amount = document.currency.formatAccounting(document.totalTTC, lang: company.formatNombre)
@@ -41,7 +49,7 @@ enum EmailService {
         document: Document,
         company: CompanyInfo,
         pdfData: Data,
-        attachmentURLs: [URL]
+        attachments: [EmailAttachment]
     ) -> SendResult {
         let lang = document.langue
         let subject = resolveTemplate(company.emailSubjectTemplate(for: lang), document: document, company: company)
@@ -62,7 +70,15 @@ enum EmailService {
         // Re-vérifie l'existence au dernier moment : un justificatif peut avoir
         // été supprimé entre la construction des URLs et l'ouverture du composer.
         var items: [Any] = [body, pdfURL]
-        items.append(contentsOf: attachmentURLs.filter { FileManager.default.fileExists(atPath: $0.path) })
+        let existing = attachments.filter { FileManager.default.fileExists(atPath: $0.sourceURL.path) }
+        // Copie chaque justificatif dans le dossier temp sous un nom lisible
+        // (libellé) plutôt que le nom de stockage en UUID.
+        for (attachment, name) in zip(existing, uniqueFilenames(for: existing)) {
+            let dest = tempDir.appendingPathComponent(name)
+            if (try? FileManager.default.copyItem(at: attachment.sourceURL, to: dest)) != nil {
+                items.append(dest)
+            }
+        }
 
         guard let service = NSSharingService(named: .composeEmail),
               service.canPerform(withItems: items) else {
@@ -82,6 +98,30 @@ enum EmailService {
             try? FileManager.default.removeItem(at: tempDir)
         }
         return .composed
+    }
+
+    /// Noms de fichiers lisibles pour une liste de justificatifs, index-alignés.
+    /// Nettoie chaque libellé via `safeFilename`, conserve l'extension, et
+    /// dédoublonne les collisions (insensibles à la casse) en suffixant `-2`, `-3`…
+    static func uniqueFilenames(for attachments: [EmailAttachment]) -> [String] {
+        var used = Set<String>()
+        return attachments.map { attachment in
+            let cleaned = safeFilename(attachment.displayName)
+            let ext = attachment.fileExtension.lowercased()
+            // Le libellé n'a pas d'extension, mais `originalFilename` (fallback)
+            // l'inclut déjà : on évite ainsi un `recu.jpg.jpg`.
+            let hasExt = !ext.isEmpty && cleaned.lowercased().hasSuffix(".\(ext)")
+            let base = hasExt ? String(cleaned.dropLast(ext.count + 1)) : cleaned
+            let suffix = ext.isEmpty ? "" : ".\(ext)"
+            var candidate = base + suffix
+            var counter = 2
+            while used.contains(candidate.lowercased()) {
+                candidate = "\(base)-\(counter)\(suffix)"
+                counter += 1
+            }
+            used.insert(candidate.lowercased())
+            return candidate
+        }
     }
 
     static func safeFilename(_ base: String) -> String {

--- a/Facio/Views/Documents/DocumentEditorView.swift
+++ b/Facio/Views/Documents/DocumentEditorView.swift
@@ -788,12 +788,12 @@ struct DocumentEditorView: View {
             return
         }
 
-        let attachmentURLs = dataStore.attachmentURLs(for: document)
+        let attachments = dataStore.emailAttachments(for: document)
         let result = EmailService.composeInvoiceEmail(
             document: document,
             company: company,
             pdfData: pdfData,
-            attachmentURLs: attachmentURLs
+            attachments: attachments
         )
         switch result {
         case .composed:


### PR DESCRIPTION
## Problème

À l'envoi d'une facture par email, les justificatifs étaient attachés sous leur nom de stockage sur disque (`<UUID>.pdf`) — illisible côté destinataire. Le PDF de la facture, lui, était déjà bien nommé car copié dans un dossier temporaire avant l'envoi.

## Correctif

On applique la même technique aux justificatifs : on joint des **copies** renommées d'après le **libellé** du justificatif (et le nom de fichier d'origine à défaut, via `DocumentAttachment.displayName`).

- `EmailService` — struct `EmailAttachment` + helper `uniqueFilenames(for:)` : nettoyage du libellé, évite la double extension (`recu.jpg` ≠ `recu.jpg.jpg`), déduplique les collisions (`-2`, `-3`…). Copie dans le dossier temp existant (nettoyé après 90 s).
- `DataStore.emailAttachments(for:)` — miroir de `attachmentURLs(for:)`, ne renvoie que les fichiers existants.
- `DocumentEditorView.envoyerParEmail` — utilise la nouvelle API.

## Tests

- Nouveau `RegressionCase` couvrant le nommage par libellé, le fallback nom de fichier et la déduplication.
- `swift build` OK ; `swift run Facio --run-regressions` → 82/82 ✅.

Aucune chaîne d'UI nouvelle (les noms viennent des données utilisateur).