### PR TITLE
fix(documents): resync DecimalField text when bound value changes

### DIFF
--- a/Facio/Views/Documents/LineItemRowView.swift
+++ b/Facio/Views/Documents/LineItemRowView.swift
@@ -221,6 +221,17 @@ struct DecimalField: View {
             .onAppear {
                 text = value == 0 ? "" : formatDecimal(value)
             }
+            // Resynchronise le texte quand la valeur liée change de l'extérieur —
+            // typiquement quand SwiftUI réutilise cette vue pour un autre document
+            // (l'éditeur de facture n'est pas recréé au changement de sélection).
+            // Sans ceci, le champ garderait la valeur du document précédent (et
+            // pourrait la réécrire sur le document courant). On n'écrase jamais une
+            // saisie en cours (champ focus).
+            .onChange(of: value) { _, newValue in
+                guard !isFocused else { return }
+                let formatted = newValue == 0 ? "" : formatDecimal(newValue)
+                if formatted != text { text = formatted }
+            }
             // Commit à chaque frappe (sans reformater) : si la vue est détruite
             // pendant la saisie (bascule compact/large au franchissement du
             // breakpoint), aucune saisie n'est perdue.


### PR DESCRIPTION
## Problème

`DecimalField` n'initialisait son texte qu'à `onAppear`. Or l'éditeur de facture n'est pas recréé quand on change de document sélectionné — SwiftUI réutilise la même vue. Le champ conservait alors la valeur du document précédent, et pouvait même la réécrire sur le document courant.

## Correctif

Ajout d'un `.onChange(of: value)` qui resynchronise le texte affiché quand la valeur liée change de l'extérieur. Garde-fous :
- On n'écrase **jamais** une saisie en cours (`guard !isFocused`).
- On ne touche au texte que s'il diffère réellement de la valeur formatée.

## Portée

1 fichier, 11 lignes ajoutées (`Facio/Views/Documents/LineItemRowView.swift`). Aucune autre modification.