### PR TITLE
feat(ui): privacy mode — hide all on-screen amounts (eye toggle)

### DIFF
--- a/Facio/Diagnostics/RegressionSuite.swift
+++ b/Facio/Diagnostics/RegressionSuite.swift
@@ -198,8 +198,25 @@ enum FacioRegressionSuite {
         RegressionCase(name: "sheet minimums fit inside minimum window", run: sheetMinimumsFitInsideMinimumWindow),
         RegressionCase(name: "color tokens resolve differently in dark mode", run: colorTokensResolveDifferentlyInDarkMode),
         RegressionCase(name: "payment date stamps on paid and feeds revenue month", run: paymentDateStampsOnPaidAndFeedsRevenueMonth),
-        RegressionCase(name: "document filter status categories are mutually exclusive", run: documentFilterStatusCategoriesAreMutuallyExclusive)
+        RegressionCase(name: "document filter status categories are mutually exclusive", run: documentFilterStatusCategoriesAreMutuallyExclusive),
+        RegressionCase(name: "privacy mode masks amounts", run: privacyModeMasksAmounts)
     ]
+
+    /// Mode confidentialité : `format` renvoie le montant formaté quand visible,
+    /// et le masque `••••` quand `hideAmounts` est actif.
+    private static func privacyModeMasksAmounts() throws {
+        let amount = Decimal(1000)
+        let privacy = PrivacyMode()
+
+        privacy.hideAmounts = false
+        try expectEqual(privacy.format(amount, .eur, lang: .fr), CurrencyType.eur.formatAccounting(amount, lang: .fr))
+
+        privacy.hideAmounts = true
+        try expectEqual(privacy.format(amount, .eur, lang: .fr), PrivacyMode.placeholder)
+        try expectEqual(privacy.format(Decimal(0), .usd, lang: .en), PrivacyMode.placeholder)
+
+        privacy.hideAmounts = false // ne pas laisser le réglage persisté à « masqué »
+    }
 
     /// Encaissement : passer en « Payée » horodate `datePaiement` (revenueDate),
     /// quitter ce statut l'efface, et un ancien payload (sans le champ) retombe

--- a/Facio/FacioApp.swift
+++ b/Facio/FacioApp.swift
@@ -9,6 +9,7 @@ struct FacioApp: App {
     @State private var networkMonitor: NetworkMonitor
     @State private var updateService: UpdateService
     @State private var toastCenter = ToastCenter()
+    @State private var privacyMode = PrivacyMode()
     @State private var showFirstLaunch = false
 
     init() {
@@ -36,6 +37,7 @@ struct FacioApp: App {
                 .environment(authService)
                 .environment(networkMonitor)
                 .environment(toastCenter)
+                .environment(privacyMode)
                 .environment(\.facioAccent, Color.appPrimary(from: dataStore.companyInfo))
                 .tint(Color.appPrimary(from: dataStore.companyInfo))
                 .frame(minWidth: FacioLayout.windowMinWidth, minHeight: FacioLayout.windowMinHeight)
@@ -99,6 +101,7 @@ struct FacioApp: App {
                 .environment(syncService)
                 .environment(authService)
                 .environment(toastCenter)
+                .environment(privacyMode)
                 .environment(\.facioAccent, Color.appPrimary(from: dataStore.companyInfo))
                 .tint(Color.appPrimary(from: dataStore.companyInfo))
         }

--- a/Facio/Localization/L10n+UX.swift
+++ b/Facio/Localization/L10n+UX.swift
@@ -47,6 +47,7 @@ extension L10n {
     static func noClientActivity(_ l: AppLanguage) -> String { l == .fr ? "Aucune activité pour ce client." : "No activity for this client." }
 
     static func commandPaletteTitle(_ l: AppLanguage) -> String { l == .fr ? "Commande rapide" : "Quick command" }
+    static func privacyToggle(_ l: AppLanguage) -> String { l == .fr ? "Masquer les montants" : "Hide amounts" }
     static func commandPalettePlaceholder(_ l: AppLanguage) -> String { l == .fr ? "Rechercher une action..." : "Search an action..." }
     static func openSettingsPayment(_ l: AppLanguage) -> String { l == .fr ? "Ouvrir les réglages de paiement" : "Open payment settings" }
     static func searchDocumentsAndClients(_ l: AppLanguage) -> String { l == .fr ? "Rechercher documents et clients" : "Search documents and clients" }

--- a/Facio/Services/PrivacyMode.swift
+++ b/Facio/Services/PrivacyMode.swift
@@ -30,4 +30,11 @@ final class PrivacyMode {
     func format(_ amount: Decimal, _ currency: CurrencyType, lang: AppLanguage) -> String {
         hideAmounts ? Self.placeholder : currency.formatAccounting(amount, lang: lang)
     }
+
+    /// Variante sans symbole de devise (montants affichés via `formatted2Decimals`,
+    /// ex. relevés d'heures : brut / net / coûts). Les heures (`…h`) ne passent PAS
+    /// par ici et restent toujours visibles.
+    func formatNumber(_ amount: Decimal, lang: AppLanguage) -> String {
+        hideAmounts ? Self.placeholder : amount.formatted2Decimals(for: lang)
+    }
 }

--- a/Facio/Services/PrivacyMode.swift
+++ b/Facio/Services/PrivacyMode.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Observation
+
+/// Mode confidentialité : masque tous les montants affichés à l'écran (remplacés
+/// par `••••`) tant qu'il est actif. Bascule via l'icône œil de la barre d'outils.
+///
+/// État global injecté dans l'environnement (comme `ToastCenter`) et **persisté**
+/// (`UserDefaults`) pour survivre aux redémarrages. N'affecte JAMAIS le PDF exporté
+/// (la vraie facture) : seul l'affichage de l'app est masqué.
+@Observable
+@MainActor
+final class PrivacyMode {
+    static let placeholder = "••••"
+    private static let storageKey = "facio_hide_amounts"
+
+    var hideAmounts: Bool {
+        didSet { UserDefaults.standard.set(hideAmounts, forKey: Self.storageKey) }
+    }
+
+    init() {
+        hideAmounts = UserDefaults.standard.bool(forKey: Self.storageKey)
+    }
+
+    func toggle() {
+        hideAmounts.toggle()
+    }
+
+    /// Point de formatage unique : le montant formaté, ou le masque si la
+    /// confidentialité est active.
+    func format(_ amount: Decimal, _ currency: CurrencyType, lang: AppLanguage) -> String {
+        hideAmounts ? Self.placeholder : currency.formatAccounting(amount, lang: lang)
+    }
+}

--- a/Facio/Views/Clients/ClientListView.swift
+++ b/Facio/Views/Clients/ClientListView.swift
@@ -345,6 +345,7 @@ struct ClientDetailView: View {
     var onCreateDocument: (DocumentType, ClientInfo) -> Void
 
     @Environment(DataStore.self) private var dataStore
+    @Environment(PrivacyMode.self) private var privacy
 
     private var lang: AppLanguage { dataStore.companyInfo.langueParDefaut }
     private var numberFormat: AppLanguage { dataStore.companyInfo.formatNombre }
@@ -418,13 +419,13 @@ struct ClientDetailView: View {
         ], spacing: FacioLayout.space12) {
             MetricTile(
                 title: L10n.clientRevenue(lang),
-                value: dataStore.companyInfo.deviseComptable.formatAccounting(totalInvoiced, lang: numberFormat),
+                value: privacy.format(totalInvoiced, dataStore.companyInfo.deviseComptable, lang: numberFormat),
                 systemImage: "doc.text",
                 color: .appRevenue
             )
             MetricTile(
                 title: L10n.clientPaid(lang),
-                value: dataStore.companyInfo.deviseComptable.formatAccounting(totalPaid, lang: numberFormat),
+                value: privacy.format(totalPaid, dataStore.companyInfo.deviseComptable, lang: numberFormat),
                 systemImage: "checkmark.circle",
                 color: .intentSuccess
             )
@@ -539,7 +540,7 @@ struct ClientDetailView: View {
                         .foregroundStyle(.secondary)
                 }
                 Spacer()
-                Text(document.currency.formatAccounting(document.totalTTC, lang: numberFormat))
+                MoneyText(amount: document.totalTTC, currency: document.currency, lang: numberFormat)
                     .font(FacioFont.amount)
                 StatusBadge(status: document.status, isOverdue: document.isOverdue)
                 Image(systemName: "chevron.right")

--- a/Facio/Views/Components/MoneyText.swift
+++ b/Facio/Views/Components/MoneyText.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+/// Affiche un montant formaté, masqué par `••••` quand le mode confidentialité
+/// est actif. Remplace `Text(currency.formatAccounting(montant, lang:))` ; les
+/// modifieurs habituels (`.font`, `.lineLimit`, `.minimumScaleFactor`,
+/// `.foregroundStyle`) se posent sur le `MoneyText` et se propagent au `Text`.
+struct MoneyText: View {
+    let amount: Decimal
+    let currency: CurrencyType
+    let lang: AppLanguage
+
+    @Environment(PrivacyMode.self) private var privacy
+
+    var body: some View {
+        Text(privacy.format(amount, currency, lang: lang))
+    }
+}

--- a/Facio/Views/ContentView.swift
+++ b/Facio/Views/ContentView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ContentView: View {
     @Environment(DataStore.self) private var dataStore
+    @Environment(PrivacyMode.self) private var privacy
     @State private var selectedSection: SidebarSection? = .dashboard
     @State private var selectedDocumentId: UUID?
     @State private var selectedTimesheetId: UUID?
@@ -123,6 +124,14 @@ struct ContentView: View {
                 }
                 .keyboardShortcut("k", modifiers: .command)
                 .help(L10n.commandPaletteTitle(lang))
+
+                Button {
+                    privacy.toggle()
+                } label: {
+                    Label(L10n.privacyToggle(lang), systemImage: privacy.hideAmounts ? "eye.slash" : "eye")
+                }
+                .keyboardShortcut("h", modifiers: [.command, .shift])
+                .help(L10n.privacyToggle(lang))
             }
         }
         .onChange(of: selectedSection) { _, newSection in

--- a/Facio/Views/Dashboard/DashboardView.swift
+++ b/Facio/Views/Dashboard/DashboardView.swift
@@ -5,6 +5,7 @@ struct DashboardView: View {
     var onSelectTimesheet: (TimesheetPeriod) -> Void = { _ in }
 
     @Environment(DataStore.self) private var dataStore
+    @Environment(PrivacyMode.self) private var privacy
 
     private var lang: AppLanguage { dataStore.companyInfo.langueParDefaut }
     private var dateFormat: AppLanguage { dataStore.companyInfo.formatDate }
@@ -106,21 +107,21 @@ struct DashboardView: View {
                 ], spacing: FacioLayout.space16) {
                     MetricTile(
                         title: L10n.revenueThisMonth(lang),
-                        value: accountingCurrency.formatAccounting(caMoisEnCours.total, lang: numberFormat),
+                        value: privacy.format(caMoisEnCours.total, accountingCurrency, lang: numberFormat),
                         subtitle: missingConversionSubtitle(caMoisEnCours),
                         systemImage: "chart.line.uptrend.xyaxis",
                         color: .appRevenue
                     )
                     MetricTile(
                         title: L10n.revenueThisYear(lang),
-                        value: accountingCurrency.formatAccounting(caAnneeEnCours.total, lang: numberFormat),
+                        value: privacy.format(caAnneeEnCours.total, accountingCurrency, lang: numberFormat),
                         subtitle: missingConversionSubtitle(caAnneeEnCours),
                         systemImage: "chart.bar.fill",
                         color: .appRevenue
                     )
                     MetricTile(
                         title: L10n.pending(lang),
-                        value: accountingCurrency.formatAccounting(montantEnAttente.total, lang: numberFormat),
+                        value: privacy.format(montantEnAttente.total, accountingCurrency, lang: numberFormat),
                         subtitle: pendingSubtitle,
                         systemImage: "clock.fill",
                         color: .appPending
@@ -291,7 +292,7 @@ struct DashboardView: View {
 
             Spacer(minLength: FacioLayout.space10)
 
-            Text(doc.currency.formatAccounting(doc.totalTTC, lang: numberFormat))
+            MoneyText(amount: doc.totalTTC, currency: doc.currency, lang: numberFormat)
                 .font(FacioFont.amount)
                 .lineLimit(1)
                 .minimumScaleFactor(0.72)

--- a/Facio/Views/Documents/DocumentEditorView.swift
+++ b/Facio/Views/Documents/DocumentEditorView.swift
@@ -237,7 +237,7 @@ struct DocumentEditorView: View {
             Text(L10n.totalTTC(lang))
                 .font(FacioFont.caption)
                 .foregroundStyle(.secondary)
-            Text(document.currency.formatAccounting(document.totalTTC, lang: dataStore.companyInfo.formatNombre))
+            MoneyText(amount: document.totalTTC, currency: document.currency, lang: dataStore.companyInfo.formatNombre)
                 .font(FacioFont.heroTotal)
                 .lineLimit(1)
                 .minimumScaleFactor(0.65)
@@ -622,7 +622,7 @@ struct DocumentEditorView: View {
 
                     if let total = document.accountingTotal(referenceCurrency: referenceCurrency) {
                         LabeledField(L10n.accountingTotal(lang)) {
-                            Text(referenceCurrency.formatAccounting(total, lang: dataStore.companyInfo.formatNombre))
+                            MoneyText(amount: total, currency: referenceCurrency, lang: dataStore.companyInfo.formatNombre)
                                 .font(.headline.monospacedDigit())
                         }
                     }

--- a/Facio/Views/Documents/DocumentLineItemsSection.swift
+++ b/Facio/Views/Documents/DocumentLineItemsSection.swift
@@ -25,6 +25,7 @@ struct DocumentLineItemsSection: View {
     let onSave: () -> Void
 
     @Environment(\.facioContainerWidth) private var containerWidth
+    @Environment(PrivacyMode.self) private var privacy
 
     /// Bascule en disposition compacte (ligne sur deux niveaux) quand la largeur
     /// ne permet plus les colonnes fixes + une désignation lisible (≈ 620 pt).
@@ -122,7 +123,7 @@ struct DocumentLineItemsSection: View {
                             HStack {
                                 Text(preset.designation)
                                 Spacer()
-                                Text("\(document.currency.formatAccounting(preset.prixUnitaire, lang: company.formatNombre))/\(L10n.unitShort(lang))")
+                                Text("\(privacy.format(preset.prixUnitaire, document.currency, lang: company.formatNombre))/\(L10n.unitShort(lang))")
                                     .foregroundStyle(.secondary)
                             }
                         }

--- a/Facio/Views/Documents/DocumentListView.swift
+++ b/Facio/Views/Documents/DocumentListView.swift
@@ -308,7 +308,7 @@ struct DocumentRowView: View {
 
             Spacer(minLength: 8)
 
-            Text(document.currency.formatAccounting(document.totalTTC, lang: numberFormat))
+            MoneyText(amount: document.totalTTC, currency: document.currency, lang: numberFormat)
                 .font(FacioFont.amount)
                 .lineLimit(1)
                 .minimumScaleFactor(0.75)

--- a/Facio/Views/Documents/DocumentSignaturesSection.swift
+++ b/Facio/Views/Documents/DocumentSignaturesSection.swift
@@ -70,7 +70,7 @@ private struct SignatureRowView: View {
                     Text(signature.date.formattedDate(for: dateFormat))
                         .font(FacioFont.captionSmall)
                         .foregroundStyle(.secondary)
-                    Text(document.currency.formatAccounting(signature.montant, lang: numberFormat))
+                    MoneyText(amount: signature.montant, currency: document.currency, lang: numberFormat)
                         .font(FacioFont.captionSmall)
                         .foregroundStyle(.secondary)
                 }

--- a/Facio/Views/Documents/LineItemRowView.swift
+++ b/Facio/Views/Documents/LineItemRowView.swift
@@ -84,7 +84,7 @@ struct LineItemRowView: View {
                     .frame(width: LineItemColumns.compactVat)
                 Spacer()
                 VStack(alignment: .trailing, spacing: FacioLayout.space2) {
-                    Text(document.currency.formatAccounting(currentLigne.totalLigne, lang: numberFormat))
+                    MoneyText(amount: currentLigne.totalLigne, currency: document.currency, lang: numberFormat)
                         .font(FacioFont.caption)
                         .foregroundStyle(.secondary)
                     totalTTCText(for: currentLigne)
@@ -153,13 +153,13 @@ struct LineItemRowView: View {
 
     /// Total HT (lecture seule)
     private func totalText(for line: LineItem) -> some View {
-        Text(document.currency.formatAccounting(line.totalLigne, lang: numberFormat))
+        MoneyText(amount: line.totalLigne, currency: document.currency, lang: numberFormat)
             .font(FacioFont.amount)
     }
 
     /// Total TTC de la ligne (HT + TVA), lecture seule.
     private func totalTTCText(for line: LineItem) -> some View {
-        Text(document.currency.formatAccounting(line.totalTTC, lang: numberFormat))
+        MoneyText(amount: line.totalTTC, currency: document.currency, lang: numberFormat)
             .font(FacioFont.amount)
     }
 

--- a/Facio/Views/Documents/TotalsView.swift
+++ b/Facio/Views/Documents/TotalsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct TotalsView: View {
     let document: Document
     @Environment(DataStore.self) private var dataStore
+    @Environment(PrivacyMode.self) private var privacy
     @Environment(\.facioWidthClass) private var widthClass
 
     private var lang: AppLanguage { dataStore.companyInfo.langueParDefaut }
@@ -27,20 +28,20 @@ struct TotalsView: View {
 
             SectionPanel {
                 VStack(alignment: .trailing, spacing: FacioLayout.space8) {
-                    totalRow(label: L10n.totalHT(lang), value: document.currency.formatAccounting(document.totalHT, lang: numberFormat), isDetail: false)
+                    totalRow(label: L10n.totalHT(lang), value: privacy.format(document.totalHT, document.currency, lang: numberFormat), isDetail: false)
 
                     // Ventilation TVA
                     if tvaBreakdown.count > 1 {
                         ForEach(tvaBreakdown, id: \.rate) { entry in
                             totalRow(
                                 label: L10n.vatRate(lang, rate: "\(entry.rate as NSDecimalNumber)"),
-                                value: document.currency.formatAccounting(entry.amount, lang: numberFormat),
+                                value: privacy.format(entry.amount, document.currency, lang: numberFormat),
                                 isDetail: true
                             )
                         }
                     }
 
-                    totalRow(label: L10n.totalTVA(lang), value: document.currency.formatAccounting(document.totalTVA, lang: numberFormat), isDetail: false)
+                    totalRow(label: L10n.totalTVA(lang), value: privacy.format(document.totalTVA, document.currency, lang: numberFormat), isDetail: false)
 
                     Divider()
 
@@ -48,7 +49,7 @@ struct TotalsView: View {
                         Text(L10n.totalTTC(lang))
                             .font(FacioFont.sectionTitle)
                         Spacer()
-                        Text(document.currency.formatAccounting(document.totalTTC, lang: numberFormat))
+                        MoneyText(amount: document.totalTTC, currency: document.currency, lang: numberFormat)
                             .font(FacioFont.amountEmphasis)
                     }
                 }

--- a/Facio/Views/TimeHub/TimeHubView.swift
+++ b/Facio/Views/TimeHub/TimeHubView.swift
@@ -41,6 +41,7 @@ struct TimeHubView: View {
     var onOpenInvoice: (Document) -> Void = { _ in }
 
     @Environment(DataStore.self) private var dataStore
+    @Environment(PrivacyMode.self) private var privacy
 
     @State private var selectedTimesheetId: UUID?
     @State private var selectedSection: TimeHubSection = .overview
@@ -231,7 +232,7 @@ struct TimeHubView: View {
             )
             MetricTile(
                 title: L10n.estimatedAmount(lang),
-                value: currency.formatAccounting(stats.estimatedAmount, lang: numberFormat),
+                value: privacy.format(stats.estimatedAmount, currency, lang: numberFormat),
                 systemImage: "banknote",
                 color: Color.appPrimary(from: dataStore.companyInfo)
             )
@@ -490,7 +491,7 @@ struct TimeHubView: View {
             HStack {
                 Label(formatDuration(group.stats.totalSeconds), systemImage: "clock")
                 Spacer()
-                Text(currency.formatAccounting(group.stats.estimatedAmount, lang: numberFormat))
+                MoneyText(amount: group.stats.estimatedAmount, currency: currency, lang: numberFormat)
                     .font(FacioFont.metaValue)
                     .foregroundStyle(.secondary)
             }
@@ -648,7 +649,7 @@ struct TimeHubView: View {
                                 Text(formatDuration(group.stats.totalSeconds))
                                     .font(FacioFont.rowValue)
                                     .foregroundStyle(.secondary)
-                                Text(currency.formatAccounting(group.stats.estimatedAmount, lang: numberFormat))
+                                MoneyText(amount: group.stats.estimatedAmount, currency: currency, lang: numberFormat)
                                     .font(FacioFont.rowValue)
                                     .foregroundStyle(.secondary)
                                 Spacer()
@@ -743,7 +744,7 @@ struct TimeHubView: View {
                 Text(formatDuration(stats.totalSeconds))
                     .font(FacioFont.rowValue)
                     .fontWeight(.semibold)
-                Text(currency.formatAccounting(stats.estimatedAmount, lang: numberFormat))
+                MoneyText(amount: stats.estimatedAmount, currency: currency, lang: numberFormat)
                     .font(FacioFont.metaValue)
                     .foregroundStyle(.secondary)
             }
@@ -873,7 +874,7 @@ private struct TimeHubEntryRow: View {
                     .font(FacioFont.rowValue)
                     .fontWeight(.semibold)
                 if context.entry.isBillable {
-                    Text((context.entry.currencySnapshot ?? defaultCurrency).formatAccounting(context.estimatedAmount(at: now), lang: numberFormat))
+                    MoneyText(amount: context.estimatedAmount(at: now), currency: context.entry.currencySnapshot ?? defaultCurrency, lang: numberFormat)
                         .font(FacioFont.metaValue)
                         .foregroundStyle(.secondary)
                 }

--- a/Facio/Views/Timesheet/TimeTrackerPanel.swift
+++ b/Facio/Views/Timesheet/TimeTrackerPanel.swift
@@ -40,6 +40,7 @@ struct TimeTrackerPanel: View {
     var onOpenInvoice: (Document) -> Void = { _ in }
 
     @Environment(DataStore.self) private var dataStore
+    @Environment(PrivacyMode.self) private var privacy
     @State private var inputMode: TimeEntryInputMode = .timer
     @State private var projectName = ""
     @State private var taskName = ""
@@ -407,7 +408,7 @@ struct TimeTrackerPanel: View {
             )
             MetricTile(
                 title: L10n.estimatedAmount(lang),
-                value: dataStore.companyInfo.deviseParDefaut.formatAccounting(estimatedBillableAmount(now: now), lang: numberFormat),
+                value: privacy.format(estimatedBillableAmount(now: now), dataStore.companyInfo.deviseParDefaut, lang: numberFormat),
                 systemImage: "banknote",
                 color: Color.appPrimary(from: dataStore.companyInfo)
             )
@@ -720,6 +721,8 @@ private struct TimeEntryRow: View {
     let onContinue: () -> Void
     let onDelete: () -> Void
 
+    @Environment(PrivacyMode.self) private var privacy
+
     var body: some View {
         HStack(alignment: .center, spacing: FacioLayout.space12) {
             Image(systemName: entry.isRunning ? "timer" : "clock")
@@ -822,7 +825,7 @@ private struct TimeEntryRow: View {
     private var estimatedAmount: String {
         let hours = Decimal(entry.duration(at: now) / 3600)
         let amount = hours * (entry.rateSnapshot ?? defaultRate)
-        return currency.formatAccounting(amount, lang: numberFormat)
+        return privacy.format(amount, currency, lang: numberFormat)
     }
 
     private func statusBadge(_ text: String, color: Color) -> some View {

--- a/Facio/Views/Timesheet/TimesheetEditorView.swift
+++ b/Facio/Views/Timesheet/TimesheetEditorView.swift
@@ -5,6 +5,7 @@ struct TimesheetEditorView: View {
     var onOpenInvoice: (Document) -> Void = { _ in }
 
     @Environment(DataStore.self) private var dataStore
+    @Environment(PrivacyMode.self) private var privacy
     @Environment(\.facioContainerWidth) private var containerWidth
     @State private var hourInputMode: TimesheetHourInputMode = .decimal
     @State private var showClientPicker = false
@@ -173,8 +174,8 @@ struct TimesheetEditorView: View {
     private func heroStatsRow(heures: Decimal, brut: Decimal, net: Decimal) -> some View {
         HStack(alignment: .center, spacing: FacioLayout.space16) {
             heroStat(L10n.totalHours(lang), value: "\(heures.formatted2Decimals(for: numberFormat))h")
-            heroStat(L10n.grossTotal(lang), value: brut.formatted2Decimals(for: numberFormat))
-            heroStat(L10n.netTotal(lang), value: net.formatted2Decimals(for: numberFormat))
+            heroStat(L10n.grossTotal(lang), value: privacy.formatNumber(brut, lang: numberFormat))
+            heroStat(L10n.netTotal(lang), value: privacy.formatNumber(net, lang: numberFormat))
         }
     }
 
@@ -352,25 +353,25 @@ struct TimesheetEditorView: View {
                 )
                 MetricTile(
                     title: L10n.normalCost(lang),
-                    value: coutNorm.formatted2Decimals(for: numberFormat),
+                    value: privacy.formatNumber(coutNorm, lang: numberFormat),
                     systemImage: "banknote",
                     color: .secondary
                 )
                 MetricTile(
                     title: L10n.overtimeCost(lang),
-                    value: coutSup.formatted2Decimals(for: numberFormat),
+                    value: privacy.formatNumber(coutSup, lang: numberFormat),
                     systemImage: "banknote",
                     color: .secondary
                 )
                 MetricTile(
                     title: L10n.grossTotal(lang),
-                    value: brut.formatted2Decimals(for: numberFormat),
+                    value: privacy.formatNumber(brut, lang: numberFormat),
                     systemImage: "sum",
                     color: .intentSuccess
                 )
                 MetricTile(
                     title: L10n.netTotal(lang),
-                    value: net.formatted2Decimals(for: numberFormat),
+                    value: privacy.formatNumber(net, lang: numberFormat),
                     systemImage: "checkmark.seal",
                     color: .intentSuccess
                 )
@@ -512,7 +513,7 @@ struct TimesheetEditorView: View {
             }
             Divider().frame(height: 14)
             let coutSemaine = norm * timesheet.tauxNormal + sup * timesheet.tauxSupplementaire
-            Text(coutSemaine.formatted2Decimals(for: numberFormat))
+            Text(privacy.formatNumber(coutSemaine, lang: numberFormat))
                 .font(FacioFont.rowValue)
                 .fontWeight(.semibold)
                 .foregroundStyle(Color.intentSuccess)

--- a/Facio/Views/Timesheet/TimesheetListView.swift
+++ b/Facio/Views/Timesheet/TimesheetListView.swift
@@ -355,6 +355,8 @@ private struct TimesheetRowView: View {
     let numberFormat: AppLanguage
     let adjacentHours: [String: Decimal]
 
+    @Environment(PrivacyMode.self) private var privacy
+
     var body: some View {
         let heuresMois = timesheet.totalHeuresDuMois()
         let heuresSup = timesheet.totalHeuresSupCrossPeriod(adjacentHours: adjacentHours)
@@ -368,7 +370,7 @@ private struct TimesheetRowView: View {
                         .lineLimit(1)
                     Spacer()
                     if brut > 0 {
-                        Text(brut.formatted2Decimals(for: numberFormat))
+                        Text(privacy.formatNumber(brut, lang: numberFormat))
                             .font(FacioFont.rowValue)
                             .fontWeight(.medium)
                             .foregroundStyle(.secondary)


### PR DESCRIPTION
Global **hide-amounts** toggle (eye icon, top-right toolbar, ⌘⇧H) that masks every monetary amount on screen with `••••` — e.g. to demo the app without revealing figures.

- New `PrivacyMode` (@Observable, persisted in UserDefaults, injected via .environment) with two formatting points: `format(_:_:lang:)` (with currency symbol) and `formatNumber(_:lang:)` (no symbol, for timesheet gross/net/costs).
- New `MoneyText` view that formats + masks via the environment; replaces direct `Text(currency.formatAccounting(...))` sites.
- Masks every amount across lists, document editor (totals & line items), dashboard KPIs & rows, client metrics & timeline, time-tracking estimates, and timesheet totals.
- **Excluded by design**: the exported PDF (the real invoice), numeric input fields, hour values (`…h`), VAT % rates, and the non-money "quotes count" tile. State persists across launches.

Strings FR/EN; a regression test pins the mask/format behaviour. 100/100 regression cases green.