### PR TITLE
feat(documents): "Partiel" invoice status with deposit tracking

### DIFF
--- a/Facio/Diagnostics/RegressionSuite.swift
+++ b/Facio/Diagnostics/RegressionSuite.swift
@@ -198,6 +198,8 @@ enum FacioRegressionSuite {
         RegressionCase(name: "sheet minimums fit inside minimum window", run: sheetMinimumsFitInsideMinimumWindow),
         RegressionCase(name: "color tokens resolve differently in dark mode", run: colorTokensResolveDifferentlyInDarkMode),
         RegressionCase(name: "payment date stamps on paid and feeds revenue month", run: paymentDateStampsOnPaidAndFeedsRevenueMonth),
+        RegressionCase(name: "partial status computes reste à payer", run: partialStatusComputesResteAPayer),
+        RegressionCase(name: "document decodes old payload without partial-payment fields", run: documentDecodesOldPayloadWithoutPartialPaymentFields),
         RegressionCase(name: "document filter status categories are mutually exclusive", run: documentFilterStatusCategoriesAreMutuallyExclusive),
         RegressionCase(name: "privacy mode masks amounts", run: privacyModeMasksAmounts)
     ]
@@ -252,6 +254,52 @@ enum FacioRegressionSuite {
         try expectEqual(decoded.revenueDate, decoded.dateCreation)
     }
 
+    /// Le statut « Partiel » horodate l'encaissement, calcule le reste à payer
+    /// (borné à [0, TTC]) et n'expose que la part encaissée au CA. Solder en
+    /// « Payée » efface l'acompte ; revenir à un statut non encaissé efface tout.
+    private static func partialStatusComputesResteAPayer() throws {
+        let doc = Document(type: .facture, number: "F1")
+        doc.ajouterLigne(LineItem(quantite: decimal("1000"), prixUnitaire: decimal("1")))
+        try expectDecimal(doc.totalTTC, equals: "1000")
+
+        // Passage en partiel : horodate l'encaissement.
+        doc.status = .partiel
+        let stamped = try require(doc.datePaiement, "partial must stamp datePaiement")
+        try expectEqual(doc.revenueDate, stamped)
+
+        doc.montantPaye = decimal("400")
+        try expectDecimal(doc.resteAPayer, equals: "600")
+        try expectDecimal(doc.montantEncaisse, equals: "400")
+        let paid = try require(doc.accountingPaidTotal(referenceCurrency: doc.currency), "same-currency paid")
+        try expectDecimal(paid, equals: "400")
+        let outstanding = try require(doc.accountingOutstandingTotal(referenceCurrency: doc.currency), "same-currency outstanding")
+        try expectDecimal(outstanding, equals: "600")
+
+        // Encaissé + restant == TTC, même pour un acompte supérieur au total
+        // (encaissé borné au TTC, restant jamais négatif).
+        doc.montantPaye = decimal("1500")
+        try expectDecimal(doc.montantEncaisse, equals: "1000")
+        try expectDecimal(doc.resteAPayer, equals: "0")
+
+        // Solder la facture efface l'acompte, encaisse le total et re-horodate le
+        // règlement (le solde ne doit pas rester rattaché au mois de l'acompte).
+        doc.montantPaye = decimal("400")
+        let acompteDate = Calendar.current.date(byAdding: .month, value: -2, to: Date())!
+        doc.datePaiement = acompteDate
+        doc.status = .payee
+        try expectEqual(doc.montantPaye, nil)
+        try expectDecimal(doc.montantEncaisse, equals: "1000")
+        try expect(doc.datePaiement != acompteDate, "settling a partial invoice re-stamps the payment date")
+
+        // Quitter un statut encaissé efface date d'encaissement et acompte.
+        doc.status = .partiel
+        doc.montantPaye = decimal("400")
+        doc.status = .brouillon
+        try expectEqual(doc.datePaiement, nil)
+        try expectEqual(doc.montantPaye, nil)
+        try expectDecimal(doc.montantEncaisse, equals: "0")
+    }
+
     /// Le filtre de liste traite « En retard » comme une catégorie distincte
     /// d'« Envoyée » : une facture envoyée dont l'échéance est dépassée ne doit
     /// PAS remonter quand on filtre « Envoyée ».
@@ -272,9 +320,16 @@ enum FacioRegressionSuite {
         let draft = Document(type: .facture, number: "F3")
         draft.status = .brouillon
 
+        // Une facture partielle reste « Partiel » même échéance dépassée : elle ne
+        // bascule pas dans « En retard » (réservé aux factures envoyées non réglées).
+        let partial = Document(type: .facture, number: "F4")
+        partial.status = .partiel
+        partial.dateEcheance = past
+
         try expectEqual(DocumentStatusFilter.category(of: onTime), .envoyee)
         try expectEqual(DocumentStatusFilter.category(of: overdue), .overdue)
         try expectEqual(DocumentStatusFilter.category(of: draft), .brouillon)
+        try expectEqual(DocumentStatusFilter.category(of: partial), .partiel)
 
         var sentFilter = DocumentFilter()
         sentFilter.statusCategories = [.envoyee]
@@ -552,6 +607,28 @@ enum FacioRegressionSuite {
         try expectEqual(document.clientTva, "")
         try expectEqual(document.clientApe, "")
         try expect(document.accountingTotal(referenceCurrency: .eur) == nil, "cross-currency old payload should need a rate")
+    }
+
+    /// Une facture sérialisée avant l'ajout du paiement partiel décode sans
+    /// acompte (montantPaye nil → reste à payer = TTC), et le statut « Partiel »
+    /// fait l'aller-retour Codable.
+    private static func documentDecodesOldPayloadWithoutPartialPaymentFields() throws {
+        let legacy = Data(#"{"typeRawValue":"Facture","statusRawValue":"Payée"}"#.utf8)
+        let document = try JSONDecoder().decode(Document.self, from: legacy)
+        try expect(document.montantPaye == nil, "old payload should not invent a paid amount")
+        try expectEqual(document.status, .payee)
+        try expectDecimal(document.resteAPayer, equals: "0")
+
+        // Round-trip du nouveau statut + acompte.
+        let partial = Document(type: .facture, number: "F1")
+        partial.ajouterLigne(LineItem(quantite: decimal("1000"), prixUnitaire: decimal("1")))
+        partial.status = .partiel
+        partial.montantPaye = decimal("250")
+        let data = try JSONEncoder().encode(partial)
+        let decoded = try JSONDecoder().decode(Document.self, from: data)
+        try expectEqual(decoded.status, .partiel)
+        try expectDecimal(try require(decoded.montantPaye, "encoded paid amount survives"), equals: "250")
+        try expectDecimal(decoded.resteAPayer, equals: "750")
     }
 
     private static func sentInvoicesBecomeOverdueAfterDueDate() throws {

--- a/Facio/Diagnostics/RegressionSuite.swift
+++ b/Facio/Diagnostics/RegressionSuite.swift
@@ -199,6 +199,7 @@ enum FacioRegressionSuite {
         RegressionCase(name: "color tokens resolve differently in dark mode", run: colorTokensResolveDifferentlyInDarkMode),
         RegressionCase(name: "payment date stamps on paid and feeds revenue month", run: paymentDateStampsOnPaidAndFeedsRevenueMonth),
         RegressionCase(name: "partial status computes reste à payer", run: partialStatusComputesResteAPayer),
+        RegressionCase(name: "partial payments bucket cash by payment date", run: partialPaymentsBucketCashByPaymentDate),
         RegressionCase(name: "document decodes old payload without partial-payment fields", run: documentDecodesOldPayloadWithoutPartialPaymentFields),
         RegressionCase(name: "document filter status categories are mutually exclusive", run: documentFilterStatusCategoriesAreMutuallyExclusive),
         RegressionCase(name: "privacy mode masks amounts", run: privacyModeMasksAmounts)
@@ -254,50 +255,89 @@ enum FacioRegressionSuite {
         try expectEqual(decoded.revenueDate, decoded.dateCreation)
     }
 
-    /// Le statut « Partiel » horodate l'encaissement, calcule le reste à payer
-    /// (borné à [0, TTC]) et n'expose que la part encaissée au CA. Solder en
-    /// « Payée » efface l'acompte ; revenir à un statut non encaissé efface tout.
+    /// Le journal des versements partiels somme les encaissements, calcule le
+    /// reste à payer (borné à [0, TTC]) et n'expose que la part reçue au CA.
+    /// Solder en « Payée » vide le journal et re-horodate ; quitter un statut
+    /// encaissé efface tout.
     private static func partialStatusComputesResteAPayer() throws {
         let doc = Document(type: .facture, number: "F1")
         doc.ajouterLigne(LineItem(quantite: decimal("1000"), prixUnitaire: decimal("1")))
         try expectDecimal(doc.totalTTC, equals: "1000")
 
-        // Passage en partiel : horodate l'encaissement.
         doc.status = .partiel
-        let stamped = try require(doc.datePaiement, "partial must stamp datePaiement")
-        try expectEqual(doc.revenueDate, stamped)
+        try expectDecimal(doc.montantEncaisse, equals: "0")
+        try expectDecimal(doc.resteAPayer, equals: "1000")
 
-        doc.montantPaye = decimal("400")
-        try expectDecimal(doc.resteAPayer, equals: "600")
-        try expectDecimal(doc.montantEncaisse, equals: "400")
+        // Plusieurs versements : la somme alimente l'encaissé, le reste suit.
+        doc.paiementsPartiels = [
+            PartialPayment(montant: decimal("400"), date: date("2026-03-15")),
+            PartialPayment(montant: decimal("150"), date: date("2026-04-10")),
+        ]
+        try expectDecimal(doc.montantPaye, equals: "550")
+        try expectDecimal(doc.montantEncaisse, equals: "550")
+        try expectDecimal(doc.resteAPayer, equals: "450")
+        try expectDecimal(doc.montantEncaisse + doc.resteAPayer, equals: "1000")
         let paid = try require(doc.accountingPaidTotal(referenceCurrency: doc.currency), "same-currency paid")
-        try expectDecimal(paid, equals: "400")
+        try expectDecimal(paid, equals: "550")
         let outstanding = try require(doc.accountingOutstandingTotal(referenceCurrency: doc.currency), "same-currency outstanding")
-        try expectDecimal(outstanding, equals: "600")
+        try expectDecimal(outstanding, equals: "450")
 
-        // Encaissé + restant == TTC, même pour un acompte supérieur au total
-        // (encaissé borné au TTC, restant jamais négatif).
-        doc.montantPaye = decimal("1500")
+        // Sur-paiement : encaissé borné au TTC, restant jamais négatif.
+        doc.paiementsPartiels.append(PartialPayment(montant: decimal("900"), date: date("2026-05-01")))
         try expectDecimal(doc.montantEncaisse, equals: "1000")
         try expectDecimal(doc.resteAPayer, equals: "0")
 
-        // Solder la facture efface l'acompte, encaisse le total et re-horodate le
-        // règlement (le solde ne doit pas rester rattaché au mois de l'acompte).
-        doc.montantPaye = decimal("400")
-        let acompteDate = Calendar.current.date(byAdding: .month, value: -2, to: Date())!
-        doc.datePaiement = acompteDate
+        // Solder depuis « Partiel » : on enregistre le reliquat comme dernier
+        // versement (daté du jour) et on CONSERVE le journal daté — l'acompte de
+        // mars n'est pas re-daté, le CA garde son attribution mensuelle.
+        doc.paiementsPartiels = [PartialPayment(montant: decimal("400"), date: date("2026-03-15"))]
         doc.status = .payee
-        try expectEqual(doc.montantPaye, nil)
+        try expect(doc.paiementsPartiels.count == 2, "settling keeps the ledger and records the balance")
         try expectDecimal(doc.montantEncaisse, equals: "1000")
-        try expect(doc.datePaiement != acompteDate, "settling a partial invoice re-stamps the payment date")
+        try expectDecimal(doc.resteAPayer, equals: "0")
+        let settledEvents = doc.accountingCashEvents(referenceCurrency: doc.currency)
+        let marchAfterSettle = try require(
+            settledEvents.first(where: { Calendar.current.isDate($0.date, equalTo: date("2026-03-01"), toGranularity: .month) }),
+            "the March installment keeps its date after settling"
+        )
+        try expectDecimal(try require(marchAfterSettle.amount, "march amount"), equals: "400")
 
-        // Quitter un statut encaissé efface date d'encaissement et acompte.
-        doc.status = .partiel
-        doc.montantPaye = decimal("400")
+        // Quitter un statut encaissé efface date et journal.
         doc.status = .brouillon
         try expectEqual(doc.datePaiement, nil)
-        try expectEqual(doc.montantPaye, nil)
+        try expect(doc.paiementsPartiels.isEmpty, "leaving a cash status clears the ledger")
         try expectDecimal(doc.montantEncaisse, equals: "0")
+    }
+
+    /// Chaque versement partiel alimente le CA à sa propre date (un acompte de
+    /// mars et un solde de juin ne tombent pas dans le même mois). Un versement
+    /// nul ne crée pas d'événement (donc pas de fausse conversion manquante).
+    private static func partialPaymentsBucketCashByPaymentDate() throws {
+        let doc = Document(type: .facture, number: "F1")
+        doc.ajouterLigne(LineItem(quantite: decimal("1000"), prixUnitaire: decimal("1"))) // EUR
+        doc.status = .partiel
+        doc.paiementsPartiels = [
+            PartialPayment(montant: decimal("400"), date: date("2026-03-15")),
+            PartialPayment(montant: decimal("600"), date: date("2026-06-20")),
+        ]
+
+        let events = doc.accountingCashEvents(referenceCurrency: .eur)
+        try expectEqual(events.count, 2)
+        let calendar = Calendar.current
+        let marchEvent = try require(
+            events.first(where: { calendar.isDate($0.date, equalTo: date("2026-03-01"), toGranularity: .month) }),
+            "a cash event must fall in March"
+        )
+        try expectDecimal(try require(marchEvent.amount, "March amount converts in same currency"), equals: "400")
+        let juneEvent = try require(
+            events.first(where: { calendar.isDate($0.date, equalTo: date("2026-06-01"), toGranularity: .month) }),
+            "a cash event must fall in June"
+        )
+        try expectDecimal(try require(juneEvent.amount, "June amount converts in same currency"), equals: "600")
+
+        // Un versement nul n'est pas un encaissement.
+        doc.paiementsPartiels.append(PartialPayment(montant: 0, date: date("2026-07-01")))
+        try expectEqual(doc.accountingCashEvents(referenceCurrency: .eur).count, 2)
     }
 
     /// Le filtre de liste traite « En retard » comme une catégorie distincte
@@ -615,20 +655,24 @@ enum FacioRegressionSuite {
     private static func documentDecodesOldPayloadWithoutPartialPaymentFields() throws {
         let legacy = Data(#"{"typeRawValue":"Facture","statusRawValue":"Payée"}"#.utf8)
         let document = try JSONDecoder().decode(Document.self, from: legacy)
-        try expect(document.montantPaye == nil, "old payload should not invent a paid amount")
+        try expect(document.paiementsPartiels.isEmpty, "old payload should not invent partial payments")
         try expectEqual(document.status, .payee)
         try expectDecimal(document.resteAPayer, equals: "0")
 
-        // Round-trip du nouveau statut + acompte.
+        // Round-trip du nouveau journal de versements.
         let partial = Document(type: .facture, number: "F1")
         partial.ajouterLigne(LineItem(quantite: decimal("1000"), prixUnitaire: decimal("1")))
         partial.status = .partiel
-        partial.montantPaye = decimal("250")
+        partial.paiementsPartiels = [
+            PartialPayment(montant: decimal("250"), date: date("2026-02-01")),
+            PartialPayment(montant: decimal("100"), date: date("2026-03-01")),
+        ]
         let data = try JSONEncoder().encode(partial)
         let decoded = try JSONDecoder().decode(Document.self, from: data)
         try expectEqual(decoded.status, .partiel)
-        try expectDecimal(try require(decoded.montantPaye, "encoded paid amount survives"), equals: "250")
-        try expectDecimal(decoded.resteAPayer, equals: "750")
+        try expectEqual(decoded.paiementsPartiels.count, 2)
+        try expectDecimal(decoded.montantPaye, equals: "350")
+        try expectDecimal(decoded.resteAPayer, equals: "650")
     }
 
     private static func sentInvoicesBecomeOverdueAfterDueDate() throws {

--- a/Facio/Diagnostics/RegressionSuite.swift
+++ b/Facio/Diagnostics/RegressionSuite.swift
@@ -293,6 +293,7 @@ enum FacioRegressionSuite {
         doc.paiementsPartiels = [PartialPayment(montant: decimal("400"), date: date("2026-03-15"))]
         doc.status = .payee
         try expect(doc.paiementsPartiels.count == 2, "settling keeps the ledger and records the balance")
+        try expect(doc.isPaidViaInstallments, "a settled-by-installments invoice keeps the memory of being partial")
         try expectDecimal(doc.montantEncaisse, equals: "1000")
         try expectDecimal(doc.resteAPayer, equals: "0")
         let settledEvents = doc.accountingCashEvents(referenceCurrency: doc.currency)

--- a/Facio/Extensions/Color+Theme.swift
+++ b/Facio/Extensions/Color+Theme.swift
@@ -67,6 +67,7 @@ extension Color {
 
     static var statusBrouillon: Color { intentNeutral }
     static var statusEnvoyee: Color { intentWarning }
+    static var statusPartiel: Color { intentInfo }
     static var statusPayee: Color { intentSuccess }
     static var statusAnnulee: Color { intentDanger }
 
@@ -74,6 +75,7 @@ extension Color {
         switch status {
         case .brouillon: return .statusBrouillon
         case .envoyee: return .statusEnvoyee
+        case .partiel: return .statusPartiel
         case .payee: return .statusPayee
         case .annulee: return .statusAnnulee
         }

--- a/Facio/Localization/L10n+Documents.swift
+++ b/Facio/Localization/L10n+Documents.swift
@@ -13,6 +13,8 @@ extension L10n {
     static func creationDate(_ l: AppLanguage) -> String { l == .fr ? "Date de création" : "Creation date" }
     static func dueDateLabel(_ l: AppLanguage) -> String { l == .fr ? "Date d'échéance" : "Due date" }
     static func paymentDate(_ l: AppLanguage) -> String { l == .fr ? "Date de paiement" : "Payment date" }
+    static func amountPaid(_ l: AppLanguage) -> String { l == .fr ? "Montant payé" : "Amount paid" }
+    static func remainingToPay(_ l: AppLanguage) -> String { l == .fr ? "Reste à payer" : "Remaining to pay" }
 
     // Devise & Paiement
     static func currencyPayment(_ l: AppLanguage) -> String { l == .fr ? "Devise & Paiement" : "Currency & Payment" }

--- a/Facio/Localization/L10n+Documents.swift
+++ b/Facio/Localization/L10n+Documents.swift
@@ -17,6 +17,9 @@ extension L10n {
     static func remainingToPay(_ l: AppLanguage) -> String { l == .fr ? "Reste à payer" : "Remaining to pay" }
     static func partialPayments(_ l: AppLanguage) -> String { l == .fr ? "Paiements partiels" : "Partial payments" }
     static func addPartialPayment(_ l: AppLanguage) -> String { l == .fr ? "Ajouter un paiement" : "Add a payment" }
+    static func payRemainingBalance(_ l: AppLanguage, amount: String) -> String {
+        l == .fr ? "Payer le reste (\(amount))" : "Pay the remainder (\(amount))"
+    }
     static func noPartialPayments(_ l: AppLanguage) -> String { l == .fr ? "Aucun paiement enregistré." : "No payment recorded yet." }
 
     // Devise & Paiement

--- a/Facio/Localization/L10n+Documents.swift
+++ b/Facio/Localization/L10n+Documents.swift
@@ -15,6 +15,9 @@ extension L10n {
     static func paymentDate(_ l: AppLanguage) -> String { l == .fr ? "Date de paiement" : "Payment date" }
     static func amountPaid(_ l: AppLanguage) -> String { l == .fr ? "Montant payé" : "Amount paid" }
     static func remainingToPay(_ l: AppLanguage) -> String { l == .fr ? "Reste à payer" : "Remaining to pay" }
+    static func partialPayments(_ l: AppLanguage) -> String { l == .fr ? "Paiements partiels" : "Partial payments" }
+    static func addPartialPayment(_ l: AppLanguage) -> String { l == .fr ? "Ajouter un paiement" : "Add a payment" }
+    static func noPartialPayments(_ l: AppLanguage) -> String { l == .fr ? "Aucun paiement enregistré." : "No payment recorded yet." }
 
     // Devise & Paiement
     static func currencyPayment(_ l: AppLanguage) -> String { l == .fr ? "Devise & Paiement" : "Currency & Payment" }

--- a/Facio/Localization/L10n+Enums.swift
+++ b/Facio/Localization/L10n+Enums.swift
@@ -13,6 +13,7 @@ extension L10n {
     static func sent(_ l: AppLanguage) -> String { l == .fr ? "Envoyée" : "Sent" }
     static func partial(_ l: AppLanguage) -> String { l == .fr ? "Partiel" : "Partial" }
     static func paid(_ l: AppLanguage) -> String { l == .fr ? "Payée" : "Paid" }
+    static func paidInInstallments(_ l: AppLanguage) -> String { l == .fr ? "Payée · versements" : "Paid · installments" }
     static func cancelled(_ l: AppLanguage) -> String { l == .fr ? "Annulée" : "Cancelled" }
 
     // PaymentMode

--- a/Facio/Localization/L10n+Enums.swift
+++ b/Facio/Localization/L10n+Enums.swift
@@ -11,6 +11,7 @@ extension L10n {
     // DocumentStatus
     static func draft(_ l: AppLanguage) -> String { l == .fr ? "Brouillon" : "Draft" }
     static func sent(_ l: AppLanguage) -> String { l == .fr ? "Envoyée" : "Sent" }
+    static func partial(_ l: AppLanguage) -> String { l == .fr ? "Partiel" : "Partial" }
     static func paid(_ l: AppLanguage) -> String { l == .fr ? "Payée" : "Paid" }
     static func cancelled(_ l: AppLanguage) -> String { l == .fr ? "Annulée" : "Cancelled" }
 

--- a/Facio/Models/Document.swift
+++ b/Facio/Models/Document.swift
@@ -237,6 +237,10 @@ final class Document: Identifiable, Codable, Hashable {
     /// donc toujours dans [0, TTC] : encaissé + restant == TTC.
     var resteAPayer: Decimal { totalTTC - montantEncaisse }
 
+    /// Facture payée mais réglée en plusieurs versements : elle est comptée comme
+    /// « Payée », tout en gardant la mémoire (et l'historique daté) du partiel.
+    var isPaidViaInstallments: Bool { status == .payee && !paiementsPartiels.isEmpty }
+
     /// Montant encore attendu pour le « Montant en attente » du tableau de bord :
     /// le total pour une facture envoyée, le solde restant pour une partielle.
     private var montantEnAttente: Decimal {

--- a/Facio/Models/Document.swift
+++ b/Facio/Models/Document.swift
@@ -88,9 +88,13 @@ final class Document: Identifiable, Codable, Hashable {
     var number: String = ""
     var dateCreation: Date = Date()
     var dateEcheance: Date = Date()
-    /// Date d'encaissement, renseignée quand la facture passe en « Payée ».
-    /// Sert à rattacher le CA au bon mois (encaissement). Nil tant que non payée.
+    /// Date d'encaissement, renseignée quand la facture passe en « Payée » ou
+    /// « Partiel ». Sert à rattacher le CA au bon mois (encaissement). Nil tant
+    /// que non encaissée.
     var datePaiement: Date?
+    /// Montant déjà encaissé quand la facture est en « Partiel » (acompte cumulé,
+    /// dans la devise du document). Nil hors statut partiel.
+    var montantPaye: Decimal?
     var statusRawValue: String = "Brouillon"
     var currencyRawValue: String = "EUR"
     var blockchainRawValue: String?
@@ -160,13 +164,24 @@ final class Document: Identifiable, Codable, Hashable {
     var status: DocumentStatus {
         get { DocumentStatus(rawValue: statusRawValue) ?? .brouillon }
         set {
+            let previous = DocumentStatus(rawValue: statusRawValue) ?? .brouillon
             statusRawValue = newValue.rawValue
-            // Encaissement : on horodate le passage en « Payée » (sans écraser une
-            // date déjà saisie) et on l'efface si on quitte ce statut.
-            if newValue == .payee {
+            // Encaissement : on horodate le passage en « Payée »/« Partiel » (sans
+            // écraser une date déjà saisie). On efface la date — et l'acompte — dès
+            // qu'on quitte un statut encaissé.
+            switch newValue {
+            case .payee:
+                // Régler intégralement = encaissement du solde à cette date. On
+                // (re)horodate à l'instant du règlement, y compris depuis « Partiel »
+                // (sinon le solde resterait rattaché au mois de l'acompte), et on
+                // solde l'acompte (la facture est entièrement réglée).
+                if datePaiement == nil || previous == .partiel { datePaiement = Date() }
+                montantPaye = nil
+            case .partiel:
                 if datePaiement == nil { datePaiement = Date() }
-            } else {
+            default:
                 datePaiement = nil
+                montantPaye = nil
             }
         }
     }
@@ -175,6 +190,30 @@ final class Document: Identifiable, Codable, Hashable {
     /// sinon la date de création (rétro-compatibilité avec les factures payées
     /// avant l'ajout du champ).
     var revenueDate: Date { datePaiement ?? dateCreation }
+
+    /// Montant réellement encaissé pour le CA : le total pour une facture payée,
+    /// l'acompte (borné à [0, TTC]) pour une facture partielle, 0 sinon.
+    var montantEncaisse: Decimal {
+        switch status {
+        case .payee: return totalTTC
+        case .partiel: return min(max(montantPaye ?? 0, 0), totalTTC)
+        default: return 0
+        }
+    }
+
+    /// Solde restant dû. Complémentaire de `montantEncaisse` (acompte borné à
+    /// [0, TTC]), donc toujours dans [0, TTC] : encaissé + restant == TTC.
+    var resteAPayer: Decimal { totalTTC - montantEncaisse }
+
+    /// Montant encore attendu pour le « Montant en attente » du tableau de bord :
+    /// le total pour une facture envoyée, le solde restant pour une partielle.
+    private var montantEnAttente: Decimal {
+        switch status {
+        case .envoyee: return totalTTC
+        case .partiel: return resteAPayer
+        default: return 0
+        }
+    }
 
     var currency: CurrencyType {
         get { decodedCurrency }
@@ -426,9 +465,12 @@ final class Document: Identifiable, Codable, Hashable {
         totalHT + totalTVA
     }
 
-    func accountingTotal(referenceCurrency: CurrencyType) -> Decimal? {
+    /// Convertit un montant (devise du document) vers la devise comptable de
+    /// référence : tel quel si même devise, sinon via le taux comptable saisi, ou
+    /// `nil` si le taux manque. Source unique des montants du CA.
+    private func convertedToAccounting(_ amount: Decimal, referenceCurrency: CurrencyType) -> Decimal? {
         if currency == referenceCurrency {
-            return totalTTC
+            return amount
         }
 
         guard accountingCurrency == referenceCurrency,
@@ -436,7 +478,21 @@ final class Document: Identifiable, Codable, Hashable {
               accountingExchangeRate > 0 else {
             return nil
         }
-        return totalTTC * accountingExchangeRate
+        return amount * accountingExchangeRate
+    }
+
+    func accountingTotal(referenceCurrency: CurrencyType) -> Decimal? {
+        convertedToAccounting(totalTTC, referenceCurrency: referenceCurrency)
+    }
+
+    /// Part encaissée convertie en devise comptable (acompte pour les partielles).
+    func accountingPaidTotal(referenceCurrency: CurrencyType) -> Decimal? {
+        convertedToAccounting(montantEncaisse, referenceCurrency: referenceCurrency)
+    }
+
+    /// Solde en attente converti en devise comptable (reste à payer des partielles).
+    func accountingOutstandingTotal(referenceCurrency: CurrencyType) -> Decimal? {
+        convertedToAccounting(montantEnAttente, referenceCurrency: referenceCurrency)
     }
 
     func needsAccountingConversion(referenceCurrency: CurrencyType) -> Bool {
@@ -557,7 +613,7 @@ final class Document: Identifiable, Codable, Hashable {
     // MARK: - Codable
 
     enum CodingKeys: String, CodingKey {
-        case id, typeRawValue, number, dateCreation, dateEcheance, datePaiement, statusRawValue
+        case id, typeRawValue, number, dateCreation, dateEcheance, datePaiement, montantPaye, statusRawValue
         case currencyRawValue, blockchainRawValue, paymentModeRawValue
         case accountingCurrencyRawValue, accountingExchangeRate, accountingExchangeRateDate
         case clientNom, clientAdresse, clientCodePostal, clientVille
@@ -580,6 +636,7 @@ final class Document: Identifiable, Codable, Hashable {
         )
         statusRawValue = try container.decodeOrDefault(String.self, forKey: .statusRawValue, default: DocumentStatus.brouillon.rawValue)
         datePaiement = try container.decodeIfPresent(Date.self, forKey: .datePaiement)
+        montantPaye = try container.decodeIfPresent(Decimal.self, forKey: .montantPaye)
         currencyRawValue = try container.decodeOrDefault(String.self, forKey: .currencyRawValue, default: CurrencyType.eur.rawValue)
         blockchainRawValue = try container.decodeIfPresent(String.self, forKey: .blockchainRawValue)
         paymentModeRawValue = try container.decodeOrDefault(String.self, forKey: .paymentModeRawValue, default: PaymentMode.aucun.rawValue)
@@ -618,6 +675,7 @@ final class Document: Identifiable, Codable, Hashable {
         try container.encode(dateEcheance, forKey: .dateEcheance)
         try container.encode(statusRawValue, forKey: .statusRawValue)
         try container.encodeIfPresent(datePaiement, forKey: .datePaiement)
+        try container.encodeIfPresent(montantPaye, forKey: .montantPaye)
         try container.encode(currencyRawValue, forKey: .currencyRawValue)
         try container.encodeIfPresent(blockchainRawValue, forKey: .blockchainRawValue)
         try container.encode(paymentModeRawValue, forKey: .paymentModeRawValue)

--- a/Facio/Models/Document.swift
+++ b/Facio/Models/Document.swift
@@ -88,13 +88,13 @@ final class Document: Identifiable, Codable, Hashable {
     var number: String = ""
     var dateCreation: Date = Date()
     var dateEcheance: Date = Date()
-    /// Date d'encaissement, renseignée quand la facture passe en « Payée » ou
-    /// « Partiel ». Sert à rattacher le CA au bon mois (encaissement). Nil tant
-    /// que non encaissée.
+    /// Date d'encaissement de la facture soldée (statut « Payée »). Sert à
+    /// rattacher le CA au bon mois. Nil tant que la facture n'est pas payée. Les
+    /// factures partielles datent chaque versement via `paiementsPartiels`.
     var datePaiement: Date?
-    /// Montant déjà encaissé quand la facture est en « Partiel » (acompte cumulé,
-    /// dans la devise du document). Nil hors statut partiel.
-    var montantPaye: Decimal?
+    /// Journal des versements partiels (statut « Partiel ») : chaque versement
+    /// porte son montant et sa date. Vide hors statut partiel.
+    var paiementsPartiels: [PartialPayment] = []
     var statusRawValue: String = "Brouillon"
     var currencyRawValue: String = "EUR"
     var blockchainRawValue: String?
@@ -165,24 +165,33 @@ final class Document: Identifiable, Codable, Hashable {
         get { DocumentStatus(rawValue: statusRawValue) ?? .brouillon }
         set {
             let previous = DocumentStatus(rawValue: statusRawValue) ?? .brouillon
-            statusRawValue = newValue.rawValue
-            // Encaissement : on horodate le passage en « Payée »/« Partiel » (sans
-            // écraser une date déjà saisie). On efface la date — et l'acompte — dès
-            // qu'on quitte un statut encaissé.
             switch newValue {
             case .payee:
-                // Régler intégralement = encaissement du solde à cette date. On
-                // (re)horodate à l'instant du règlement, y compris depuis « Partiel »
-                // (sinon le solde resterait rattaché au mois de l'acompte), et on
-                // solde l'acompte (la facture est entièrement réglée).
-                if datePaiement == nil || previous == .partiel { datePaiement = Date() }
-                montantPaye = nil
+                if previous == .partiel {
+                    // Solder depuis « Partiel » : on enregistre le reliquat éventuel
+                    // comme dernier versement daté du jour et on CONSERVE le journal
+                    // daté — le CA garde l'attribution mois par mois des encaissements
+                    // (re-dater l'ensemble effacerait l'historique des versements).
+                    paiementsPartiels.removeAll { $0.montant == 0 }
+                    let collected = min(max(montantPaye, 0), totalTTC)
+                    let remaining = totalTTC - collected
+                    if remaining > 0 {
+                        paiementsPartiels.append(PartialPayment(montant: remaining, date: Date()))
+                    }
+                    datePaiement = paiementsPartiels.map(\.date).max()
+                } else {
+                    // Encaissement en une fois : on horodate le règlement.
+                    if datePaiement == nil { datePaiement = Date() }
+                    paiementsPartiels = []
+                }
             case .partiel:
-                if datePaiement == nil { datePaiement = Date() }
+                // Les dates d'encaissement vivent dans le journal des versements.
+                datePaiement = nil
             default:
                 datePaiement = nil
-                montantPaye = nil
+                paiementsPartiels = []
             }
+            statusRawValue = newValue.rawValue
         }
     }
 
@@ -191,18 +200,41 @@ final class Document: Identifiable, Codable, Hashable {
     /// avant l'ajout du champ).
     var revenueDate: Date { datePaiement ?? dateCreation }
 
-    /// Montant réellement encaissé pour le CA : le total pour une facture payée,
-    /// l'acompte (borné à [0, TTC]) pour une facture partielle, 0 sinon.
+    /// Somme brute des versements partiels saisis (devise du document).
+    var montantPaye: Decimal { paiementsPartiels.reduce(Decimal.zero) { $0 + $1.montant } }
+
+    /// Versements datés effectivement comptés, plafonnés **cumulativement** à
+    /// [0, TTC] dans l'ordre chronologique : un trop-perçu ne gonfle pas le CA et
+    /// un versement nul/négatif est ignoré. Chaque versement conserve sa date.
+    /// Source unique de l'encaissement (montant + ventilation mensuelle).
+    private var datedCashContributions: [(date: Date, amount: Decimal)] {
+        var remaining = totalTTC
+        var result: [(date: Date, amount: Decimal)] = []
+        for payment in paiementsPartiels.sorted(by: { $0.date < $1.date }) {
+            guard remaining > 0 else { break }
+            guard payment.montant > 0 else { continue }
+            let amount = min(payment.montant, remaining)
+            remaining -= amount
+            result.append((date: payment.date, amount: amount))
+        }
+        return result
+    }
+
+    /// Montant réellement encaissé pour le CA : le total pour une facture payée
+    /// en une fois, sinon la somme (plafonnée à TTC) des versements enregistrés.
     var montantEncaisse: Decimal {
         switch status {
-        case .payee: return totalTTC
-        case .partiel: return min(max(montantPaye ?? 0, 0), totalTTC)
-        default: return 0
+        case .payee where paiementsPartiels.isEmpty:
+            return totalTTC
+        case .payee, .partiel:
+            return datedCashContributions.reduce(Decimal.zero) { $0 + $1.amount }
+        default:
+            return 0
         }
     }
 
-    /// Solde restant dû. Complémentaire de `montantEncaisse` (acompte borné à
-    /// [0, TTC]), donc toujours dans [0, TTC] : encaissé + restant == TTC.
+    /// Solde restant dû. Complémentaire de `montantEncaisse` (borné à [0, TTC]),
+    /// donc toujours dans [0, TTC] : encaissé + restant == TTC.
     var resteAPayer: Decimal { totalTTC - montantEncaisse }
 
     /// Montant encore attendu pour le « Montant en attente » du tableau de bord :
@@ -212,6 +244,23 @@ final class Document: Identifiable, Codable, Hashable {
         case .envoyee: return totalTTC
         case .partiel: return resteAPayer
         default: return 0
+        }
+    }
+
+    /// Encaissements datés convertis en devise comptable, pour ventiler le CA par
+    /// mois : une facture soldée par versements (ou partielle) compte chaque
+    /// versement à sa propre date ; une facture payée en une fois compte son total
+    /// à sa date de paiement. `amount` vaut `nil` quand la conversion manque.
+    func accountingCashEvents(referenceCurrency: CurrencyType) -> [(date: Date, amount: Decimal?)] {
+        switch status {
+        case .payee where paiementsPartiels.isEmpty:
+            return [(revenueDate, convertedToAccounting(totalTTC, referenceCurrency: referenceCurrency))]
+        case .payee, .partiel:
+            return datedCashContributions.map {
+                (date: $0.date, amount: convertedToAccounting($0.amount, referenceCurrency: referenceCurrency))
+            }
+        default:
+            return []
         }
     }
 
@@ -613,7 +662,7 @@ final class Document: Identifiable, Codable, Hashable {
     // MARK: - Codable
 
     enum CodingKeys: String, CodingKey {
-        case id, typeRawValue, number, dateCreation, dateEcheance, datePaiement, montantPaye, statusRawValue
+        case id, typeRawValue, number, dateCreation, dateEcheance, datePaiement, paiementsPartiels, statusRawValue
         case currencyRawValue, blockchainRawValue, paymentModeRawValue
         case accountingCurrencyRawValue, accountingExchangeRate, accountingExchangeRateDate
         case clientNom, clientAdresse, clientCodePostal, clientVille
@@ -636,7 +685,7 @@ final class Document: Identifiable, Codable, Hashable {
         )
         statusRawValue = try container.decodeOrDefault(String.self, forKey: .statusRawValue, default: DocumentStatus.brouillon.rawValue)
         datePaiement = try container.decodeIfPresent(Date.self, forKey: .datePaiement)
-        montantPaye = try container.decodeIfPresent(Decimal.self, forKey: .montantPaye)
+        paiementsPartiels = try container.decodeOrDefault([PartialPayment].self, forKey: .paiementsPartiels, default: [])
         currencyRawValue = try container.decodeOrDefault(String.self, forKey: .currencyRawValue, default: CurrencyType.eur.rawValue)
         blockchainRawValue = try container.decodeIfPresent(String.self, forKey: .blockchainRawValue)
         paymentModeRawValue = try container.decodeOrDefault(String.self, forKey: .paymentModeRawValue, default: PaymentMode.aucun.rawValue)
@@ -675,7 +724,7 @@ final class Document: Identifiable, Codable, Hashable {
         try container.encode(dateEcheance, forKey: .dateEcheance)
         try container.encode(statusRawValue, forKey: .statusRawValue)
         try container.encodeIfPresent(datePaiement, forKey: .datePaiement)
-        try container.encodeIfPresent(montantPaye, forKey: .montantPaye)
+        try container.encode(paiementsPartiels, forKey: .paiementsPartiels)
         try container.encode(currencyRawValue, forKey: .currencyRawValue)
         try container.encodeIfPresent(blockchainRawValue, forKey: .blockchainRawValue)
         try container.encode(paymentModeRawValue, forKey: .paymentModeRawValue)

--- a/Facio/Models/Enums.swift
+++ b/Facio/Models/Enums.swift
@@ -50,6 +50,7 @@ enum DocumentType: String, Codable, CaseIterable, Identifiable {
 enum DocumentStatus: String, Codable, CaseIterable, Identifiable {
     case brouillon = "Brouillon"
     case envoyee = "Envoyée"
+    case partiel = "Partiel"
     case payee = "Payée"
     case annulee = "Annulée"
 
@@ -61,6 +62,7 @@ enum DocumentStatus: String, Codable, CaseIterable, Identifiable {
         switch self {
         case .brouillon: return L10n.draft(lang)
         case .envoyee: return L10n.sent(lang)
+        case .partiel: return L10n.partial(lang)
         case .payee: return L10n.paid(lang)
         case .annulee: return L10n.cancelled(lang)
         }
@@ -70,6 +72,7 @@ enum DocumentStatus: String, Codable, CaseIterable, Identifiable {
         switch self {
         case .brouillon: return "gray"
         case .envoyee: return "orange"
+        case .partiel: return "blue"
         case .payee: return "green"
         case .annulee: return "red"
         }

--- a/Facio/Models/PartialPayment.swift
+++ b/Facio/Models/PartialPayment.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Un versement partiel encaissé sur une facture (statut « Partiel ») : un
+/// montant reçu à une date donnée. La somme des versements donne le montant
+/// encaissé ; le reste à payer en découle. Chaque versement porte sa propre date
+/// pour rattacher le CA au bon mois (encaissement).
+struct PartialPayment: Codable, Identifiable, Hashable {
+    var id: UUID
+    var montant: Decimal
+    var date: Date
+
+    init(id: UUID = UUID(), montant: Decimal = 0, date: Date = Date()) {
+        self.id = id
+        self.montant = montant
+        self.date = date
+    }
+}

--- a/Facio/PDF/PDFGenerator.swift
+++ b/Facio/PDF/PDFGenerator.swift
@@ -593,7 +593,7 @@ struct PDFGenerator {
         // Le restant est calculé sur le TTC affiché pour rester cohérent au centime.
         if document.status == .partiel {
             cy += 6
-            let paid = max(0, min(document.montantPaye ?? 0, totals.totalTTC))
+            let paid = min(document.montantEncaisse, totals.totalTTC)
             let reste = totals.totalTTC - paid
             drawTextRight(L10n.amountPaid(lang), rightX: labelRight, y: cy,
                           font: PDFLayout.fontBody, color: PDFLayout.textBlack, context: context)

--- a/Facio/PDF/PDFGenerator.swift
+++ b/Facio/PDF/PDFGenerator.swift
@@ -589,6 +589,24 @@ struct PDFGenerator {
                       font: PDFLayout.fontTotalTTC, color: PDFLayout.textBlack, context: context)
         cy += 20
 
+        // Paiement partiel : acompte encaissé + solde restant, sous le Total TTC.
+        // Le restant est calculé sur le TTC affiché pour rester cohérent au centime.
+        if document.status == .partiel {
+            cy += 6
+            let paid = max(0, min(document.montantPaye ?? 0, totals.totalTTC))
+            let reste = totals.totalTTC - paid
+            drawTextRight(L10n.amountPaid(lang), rightX: labelRight, y: cy,
+                          font: PDFLayout.fontBody, color: PDFLayout.textBlack, context: context)
+            drawTextRight("\(formatSpaced(paid)) \(cur)", rightX: valueRight, y: cy,
+                          font: PDFLayout.fontBody, color: PDFLayout.textBlack, context: context)
+            cy += 17
+            drawTextRight(L10n.remainingToPay(lang), rightX: labelRight, y: cy,
+                          font: PDFLayout.fontTotalTTC, color: themePrimary, context: context)
+            drawTextRight("\(formatSpaced(reste)) \(cur)", rightX: valueRight, y: cy,
+                          font: PDFLayout.fontTotalTTC, color: themePrimary, context: context)
+            cy += 20
+        }
+
         return cy
     }
 

--- a/Facio/Services/AccountingRevenueService.swift
+++ b/Facio/Services/AccountingRevenueService.swift
@@ -7,13 +7,19 @@ struct AccountingRevenueSummary: Equatable {
 }
 
 struct AccountingRevenueService {
+    /// Agrège un montant comptable par document. `amount` choisit la part sommée
+    /// (total complet par défaut, ou part encaissée / solde restant pour le suivi
+    /// des paiements partiels) ; il renvoie `nil` quand la conversion manque.
     static func summary(
         for documents: [Document],
-        referenceCurrency: CurrencyType
+        referenceCurrency: CurrencyType,
+        amount: (Document, CurrencyType) -> Decimal? = { document, ref in
+            document.accountingTotal(referenceCurrency: ref)
+        }
     ) -> AccountingRevenueSummary {
         documents.reduce(AccountingRevenueSummary()) { partial, document in
             var summary = partial
-            if let converted = document.accountingTotal(referenceCurrency: referenceCurrency) {
+            if let converted = amount(document, referenceCurrency) {
                 summary.total += converted
                 summary.convertedCount += 1
             } else if document.needsAccountingConversion(referenceCurrency: referenceCurrency) {

--- a/Facio/Views/Clients/ClientListView.swift
+++ b/Facio/Views/Clients/ClientListView.swift
@@ -60,7 +60,11 @@ struct ClientListView: View {
         for client in result {
             let inv = invoices(for: client)
             let invoiced = AccountingRevenueService.summary(for: inv, referenceCurrency: ref).total
-            let paid = AccountingRevenueService.summary(for: inv.filter { $0.status == .payee }, referenceCurrency: ref).total
+            let paid = AccountingRevenueService.summary(
+                for: inv.filter { $0.status == .payee || $0.status == .partiel },
+                referenceCurrency: ref,
+                amount: { $0.accountingPaidTotal(referenceCurrency: $1) }
+            ).total
             let hasUnpaid = inv.contains { $0.status != .payee && $0.status != .annulee }
             metrics[client.id] = (invoiced, paid, hasUnpaid)
         }
@@ -369,8 +373,9 @@ struct ClientDetailView: View {
 
     private var totalPaid: Decimal {
         AccountingRevenueService.summary(
-            for: relatedInvoices.filter { $0.status == .payee },
-            referenceCurrency: dataStore.companyInfo.deviseComptable
+            for: relatedInvoices.filter { $0.status == .payee || $0.status == .partiel },
+            referenceCurrency: dataStore.companyInfo.deviseComptable,
+            amount: { $0.accountingPaidTotal(referenceCurrency: $1) }
         ).total
     }
 

--- a/Facio/Views/Clients/ClientListView.swift
+++ b/Facio/Views/Clients/ClientListView.swift
@@ -547,7 +547,7 @@ struct ClientDetailView: View {
                 Spacer()
                 MoneyText(amount: document.totalTTC, currency: document.currency, lang: numberFormat)
                     .font(FacioFont.amount)
-                StatusBadge(status: document.status, isOverdue: document.isOverdue)
+                StatusBadge(status: document.status, isOverdue: document.isOverdue, paidViaInstallments: document.isPaidViaInstallments)
                 Image(systemName: "chevron.right")
                     .font(.caption)
                     .foregroundStyle(.tertiary)

--- a/Facio/Views/Components/StatusBadge.swift
+++ b/Facio/Views/Components/StatusBadge.swift
@@ -13,6 +13,7 @@ struct StatusBadge: View {
         switch status {
         case .brouillon: return "pencil"
         case .envoyee: return "paperplane.fill"
+        case .partiel: return "circle.lefthalf.filled"
         case .payee: return "checkmark.circle.fill"
         case .annulee: return "xmark.circle.fill"
         }

--- a/Facio/Views/Components/StatusBadge.swift
+++ b/Facio/Views/Components/StatusBadge.swift
@@ -3,13 +3,20 @@ import SwiftUI
 struct StatusBadge: View {
     let status: DocumentStatus
     var isOverdue: Bool = false
+    /// Facture « Payée » mais réglée en plusieurs versements : badge distinct.
+    var paidViaInstallments: Bool = false
     @Environment(DataStore.self) private var dataStore
 
     private var lang: AppLanguage { dataStore.companyInfo.langueParDefaut }
     private var color: Color { isOverdue ? Color.intentDanger : Color.statusColor(for: status) }
-    private var label: String { isOverdue ? L10n.overdue(lang) : status.label(for: lang) }
+    private var label: String {
+        if isOverdue { return L10n.overdue(lang) }
+        if paidViaInstallments { return L10n.paidInInstallments(lang) }
+        return status.label(for: lang)
+    }
     private var icon: String {
         if isOverdue { return "exclamationmark.triangle.fill" }
+        if paidViaInstallments { return "calendar.badge.checkmark" }
         switch status {
         case .brouillon: return "pencil"
         case .envoyee: return "paperplane.fill"

--- a/Facio/Views/Dashboard/DashboardView.swift
+++ b/Facio/Views/Dashboard/DashboardView.swift
@@ -24,11 +24,10 @@ struct DashboardView: View {
         allDocuments.filter { $0.type == .devis }
     }
 
-    // Factures dont une part est encaissée (payées + partielles avec acompte) :
-    // elles alimentent le CA, à hauteur du montant réellement reçu. Une partielle
-    // sans acompte (0 reçu) est exclue pour ne pas fausser comptes et conversions.
+    // Factures dont une part est encaissée (payées + partielles) : elles
+    // alimentent le CA à hauteur des encaissements, chacun rattaché à sa date.
     private var facturesEncaissees: [Document] {
-        factures.filter { $0.status == .payee || ($0.status == .partiel && $0.montantEncaisse > 0) }
+        factures.filter { $0.status == .payee || $0.status == .partiel }
     }
 
     private var facturesEnAttente: [Document] {
@@ -41,31 +40,33 @@ struct DashboardView: View {
         factures.filter { $0.status == .envoyee || ($0.status == .partiel && $0.resteAPayer > 0) }
     }
 
-    // CA du mois en cours
-    private var caMoisEnCours: AccountingRevenueSummary {
+    /// CA d'une période : on ventile chaque encaissement (total d'une facture
+    /// payée, ou chaque versement d'une partielle) dans son propre mois/année.
+    private func caSummary(toGranularity granularity: Calendar.Component) -> AccountingRevenueSummary {
         let calendar = Calendar.current
         let now = Date()
-        let documents = facturesEncaissees
-            .filter { calendar.isDate($0.revenueDate, equalTo: now, toGranularity: .month) }
-        return AccountingRevenueService.summary(
-            for: documents,
-            referenceCurrency: accountingCurrency,
-            amount: { $0.accountingPaidTotal(referenceCurrency: $1) }
-        )
+        var summary = AccountingRevenueSummary()
+        for facture in facturesEncaissees {
+            var missingConversion = false
+            for event in facture.accountingCashEvents(referenceCurrency: accountingCurrency)
+            where calendar.isDate(event.date, equalTo: now, toGranularity: granularity) {
+                if let amount = event.amount {
+                    summary.total += amount
+                    summary.convertedCount += 1
+                } else {
+                    missingConversion = true
+                }
+            }
+            if missingConversion { summary.missingConversionCount += 1 }
+        }
+        return summary
     }
 
+    // CA du mois en cours
+    private var caMoisEnCours: AccountingRevenueSummary { caSummary(toGranularity: .month) }
+
     // CA de l'annee en cours
-    private var caAnneeEnCours: AccountingRevenueSummary {
-        let calendar = Calendar.current
-        let now = Date()
-        let documents = facturesEncaissees
-            .filter { calendar.isDate($0.revenueDate, equalTo: now, toGranularity: .year) }
-        return AccountingRevenueService.summary(
-            for: documents,
-            referenceCurrency: accountingCurrency,
-            amount: { $0.accountingPaidTotal(referenceCurrency: $1) }
-        )
-    }
+    private var caAnneeEnCours: AccountingRevenueSummary { caSummary(toGranularity: .year) }
 
     // Montant en attente (solde restant dû, partielles incluses)
     private var montantEnAttente: AccountingRevenueSummary {

--- a/Facio/Views/Dashboard/DashboardView.swift
+++ b/Facio/Views/Dashboard/DashboardView.swift
@@ -310,7 +310,7 @@ struct DashboardView: View {
                 .lineLimit(1)
                 .minimumScaleFactor(0.72)
                 .frame(minWidth: 92, maxWidth: 130, alignment: .trailing)
-            StatusBadge(status: doc.status, isOverdue: doc.isOverdue)
+            StatusBadge(status: doc.status, isOverdue: doc.isOverdue, paidViaInstallments: doc.isPaidViaInstallments)
             Image(systemName: "chevron.right")
                 .font(.caption)
                 .foregroundStyle(.tertiary)

--- a/Facio/Views/Dashboard/DashboardView.swift
+++ b/Facio/Views/Dashboard/DashboardView.swift
@@ -24,23 +24,33 @@ struct DashboardView: View {
         allDocuments.filter { $0.type == .devis }
     }
 
-    private var facturesPayees: [Document] {
-        factures.filter { $0.status == .payee }
+    // Factures dont une part est encaissée (payées + partielles avec acompte) :
+    // elles alimentent le CA, à hauteur du montant réellement reçu. Une partielle
+    // sans acompte (0 reçu) est exclue pour ne pas fausser comptes et conversions.
+    private var facturesEncaissees: [Document] {
+        factures.filter { $0.status == .payee || ($0.status == .partiel && $0.montantEncaisse > 0) }
     }
 
     private var facturesEnAttente: [Document] {
         factures.filter { $0.status == .envoyee }
     }
 
+    // Factures avec un solde encore dû : envoyées + partielles dont il reste à
+    // payer (une partielle intégralement reçue n'attend plus rien).
+    private var outstandingInvoices: [Document] {
+        factures.filter { $0.status == .envoyee || ($0.status == .partiel && $0.resteAPayer > 0) }
+    }
+
     // CA du mois en cours
     private var caMoisEnCours: AccountingRevenueSummary {
         let calendar = Calendar.current
         let now = Date()
-        let documents = facturesPayees
+        let documents = facturesEncaissees
             .filter { calendar.isDate($0.revenueDate, equalTo: now, toGranularity: .month) }
         return AccountingRevenueService.summary(
             for: documents,
-            referenceCurrency: accountingCurrency
+            referenceCurrency: accountingCurrency,
+            amount: { $0.accountingPaidTotal(referenceCurrency: $1) }
         )
     }
 
@@ -48,19 +58,21 @@ struct DashboardView: View {
     private var caAnneeEnCours: AccountingRevenueSummary {
         let calendar = Calendar.current
         let now = Date()
-        let documents = facturesPayees
+        let documents = facturesEncaissees
             .filter { calendar.isDate($0.revenueDate, equalTo: now, toGranularity: .year) }
         return AccountingRevenueService.summary(
             for: documents,
-            referenceCurrency: accountingCurrency
+            referenceCurrency: accountingCurrency,
+            amount: { $0.accountingPaidTotal(referenceCurrency: $1) }
         )
     }
 
-    // Montant en attente
+    // Montant en attente (solde restant dû, partielles incluses)
     private var montantEnAttente: AccountingRevenueSummary {
         AccountingRevenueService.summary(
-            for: facturesEnAttente,
-            referenceCurrency: accountingCurrency
+            for: outstandingInvoices,
+            referenceCurrency: accountingCurrency,
+            amount: { $0.accountingOutstandingTotal(referenceCurrency: $1) }
         )
     }
 
@@ -69,7 +81,7 @@ struct DashboardView: View {
     }
 
     private var awaitingPaymentInvoices: [Document] {
-        facturesEnAttente.filter { !$0.isOverdue }
+        outstandingInvoices.filter { !$0.isOverdue }
     }
 
     private var quotesToFollowUp: [Document] {
@@ -196,9 +208,9 @@ struct DashboardView: View {
 
     private var pendingSubtitle: String {
         if montantEnAttente.missingConversionCount > 0 {
-            return "\(L10n.pendingInvoices(lang, count: facturesEnAttente.count)) - \(L10n.missingConversions(lang, count: montantEnAttente.missingConversionCount))"
+            return "\(L10n.pendingInvoices(lang, count: outstandingInvoices.count)) - \(L10n.missingConversions(lang, count: montantEnAttente.missingConversionCount))"
         }
-        return L10n.pendingInvoices(lang, count: facturesEnAttente.count)
+        return L10n.pendingInvoices(lang, count: outstandingInvoices.count)
     }
 
     private func missingConversionSubtitle(_ summary: AccountingRevenueSummary) -> String? {
@@ -340,7 +352,7 @@ struct DashboardView: View {
     }
 
     private func documentRowDetail(_ doc: Document) -> String {
-        if doc.type == .facture && (doc.status == .envoyee || doc.isOverdue) {
+        if doc.type == .facture && (doc.status == .envoyee || doc.status == .partiel || doc.isOverdue) {
             return "\(L10n.dueDateLabel(lang)): \(doc.dateEcheance.formattedDate(for: dateFormat))"
         }
         return doc.dateCreation.formattedDate(for: dateFormat)

--- a/Facio/Views/Documents/DocumentEditorView.swift
+++ b/Facio/Views/Documents/DocumentEditorView.swift
@@ -213,7 +213,7 @@ struct DocumentEditorView: View {
                 Text(document.type.label(for: lang))
                     .font(FacioFont.subsectionTitle)
                     .foregroundStyle(Color.appPrimary(from: company))
-                StatusBadge(status: document.status, isOverdue: document.isOverdue)
+                StatusBadge(status: document.status, isOverdue: document.isOverdue, paidViaInstallments: document.isPaidViaInstallments)
             }
 
             TextField(L10n.number(lang), text: Binding(
@@ -568,7 +568,7 @@ struct DocumentEditorView: View {
                         }
                         Button(role: .destructive) {
                             document.paiementsPartiels.removeAll { $0.id == payment.id }
-                            saveDocument()
+                            saveAfterLedgerChange()
                         } label: {
                             Image(systemName: "trash")
                         }
@@ -631,6 +631,26 @@ struct DocumentEditorView: View {
         } else {
             document.paiementsPartiels.append(PartialPayment(montant: reste, date: Date()))
         }
+        saveAfterLedgerChange()
+    }
+
+    /// Aligne le statut sur l'encaissement du journal. N'est appelée que depuis
+    /// l'édition d'un journal existant (montant, suppression, « Payer le reste »).
+    /// Une facture partielle intégralement réglée passe en « Payée » (journal daté
+    /// conservé = mémoire du paiement en plusieurs fois) ; à l'inverse, une facture
+    /// soldée par versements repassée sous 100 % — ou dont on a supprimé tous les
+    /// versements — redevient « Partiel » (sinon elle resterait « Payée » avec un
+    /// journal vide et un encaissé qui rebascule au TTC complet).
+    private func reconcilePartialStatus() {
+        if document.status == .partiel, document.montantEncaisse > 0, document.resteAPayer == 0 {
+            document.status = .payee
+        } else if document.status == .payee, document.resteAPayer > 0 || document.paiementsPartiels.isEmpty {
+            document.status = .partiel
+        }
+    }
+
+    private func saveAfterLedgerChange() {
+        reconcilePartialStatus()
         saveDocument()
     }
 
@@ -651,7 +671,7 @@ struct DocumentEditorView: View {
             set: { newValue in
                 guard let index = document.paiementsPartiels.firstIndex(where: { $0.id == payment.id }) else { return }
                 document.paiementsPartiels[index].montant = newValue
-                saveDocument()
+                saveAfterLedgerChange()
             }
         )
     }

--- a/Facio/Views/Documents/DocumentEditorView.swift
+++ b/Facio/Views/Documents/DocumentEditorView.swift
@@ -470,6 +470,10 @@ struct DocumentEditorView: View {
                             if newStatus == .envoyee {
                                 _ = document.freezePaymentSnapshot(from: company)
                             }
+                            // Premier versement prêt à saisir dès qu'on passe en partiel.
+                            if newStatus == .partiel && document.paiementsPartiels.isEmpty {
+                                document.paiementsPartiels.append(PartialPayment())
+                            }
                             prepareAccountingConversionIfNeeded()
                             saveDocument()
                             if newStatus == .payee && document.currency.isCrypto
@@ -517,45 +521,107 @@ struct DocumentEditorView: View {
                     set: { document.dateEcheance = $0; saveDocument() }
                 ), displayedComponents: .date)
             }
-            // Date d'encaissement : rattache le CA au bon mois. Visible quand la
-            // facture est payée ou partiellement réglée.
-            if document.status == .payee || document.status == .partiel {
+            // Date d'encaissement (facture payée en une fois) : rattache le CA au
+            // bon mois. Une facture soldée par versements montre son journal.
+            if document.status == .payee && document.paiementsPartiels.isEmpty {
                 DatePicker(L10n.paymentDate(lang), selection: Binding(
                     get: { document.datePaiement ?? document.dateCreation },
                     set: { document.datePaiement = $0; saveDocument() }
                 ), displayedComponents: .date)
-                .tint(document.status == .partiel ? .intentInfo : .intentSuccess)
+                .tint(.intentSuccess)
             }
-            // Paiement partiel : acompte encaissé saisi + reste à payer calculé.
-            if document.status == .partiel {
-                HStack(alignment: .top, spacing: FacioLayout.space24) {
-                    LabeledField(L10n.amountPaid(lang)) {
+            // Journal des versements : statut partiel, ou facture soldée par
+            // versements successifs.
+            if document.status == .partiel || (document.status == .payee && !document.paiementsPartiels.isEmpty) {
+                partialPaymentsEditor
+            }
+        }
+    }
+
+    // MARK: - Paiements partiels
+
+    private var partialPaymentsEditor: some View {
+        VStack(alignment: .leading, spacing: FacioLayout.space8) {
+            subsectionHeader(L10n.partialPayments(lang))
+
+            if document.paiementsPartiels.isEmpty {
+                Text(L10n.noPartialPayments(lang))
+                    .font(FacioFont.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(document.paiementsPartiels) { payment in
+                    HStack(spacing: FacioLayout.space12) {
+                        DatePicker("", selection: paymentDateBinding(payment), displayedComponents: .date)
+                            .labelsHidden()
+                            .tint(.intentInfo)
                         HStack(spacing: FacioLayout.space8) {
                             DecimalField(
                                 placeholder: "0",
-                                value: Binding(
-                                    get: { document.montantPaye ?? 0 },
-                                    set: { document.montantPaye = $0; saveDocument() }
-                                ),
+                                value: paymentAmountBinding(payment),
                                 maximumFractionDigits: document.currency.maximumFractionDigits,
                                 format: dataStore.companyInfo.formatNombre
                             )
                             .density(.regular)
-                            .frame(maxWidth: 160)
+                            .frame(maxWidth: 140)
                             Text(document.currency.label)
                                 .foregroundStyle(.secondary)
                         }
-                    }
-                    LabeledField(L10n.remainingToPay(lang)) {
-                        MoneyText(
-                            amount: document.resteAPayer,
-                            currency: document.currency,
-                            lang: dataStore.companyInfo.formatNombre
-                        )
+                        Button(role: .destructive) {
+                            document.paiementsPartiels.removeAll { $0.id == payment.id }
+                            saveDocument()
+                        } label: {
+                            Image(systemName: "trash")
+                        }
+                        .buttonStyle(.borderless)
+                        .foregroundStyle(.secondary)
+                        .help(L10n.delete(lang))
                     }
                 }
             }
+
+            Button {
+                document.paiementsPartiels.append(PartialPayment())
+                saveDocument()
+            } label: {
+                Label(L10n.addPartialPayment(lang), systemImage: "plus.circle")
+            }
+            .buttonStyle(.borderless)
+            .tint(.intentInfo)
+
+            Divider().padding(.vertical, FacioLayout.space4)
+
+            HStack(spacing: FacioLayout.space24) {
+                LabeledField(L10n.amountPaid(lang)) {
+                    MoneyText(amount: document.montantEncaisse, currency: document.currency, lang: dataStore.companyInfo.formatNombre)
+                }
+                LabeledField(L10n.remainingToPay(lang)) {
+                    MoneyText(amount: document.resteAPayer, currency: document.currency, lang: dataStore.companyInfo.formatNombre)
+                        .foregroundStyle(document.resteAPayer == 0 ? Color.intentSuccess : Color.intentInfo)
+                }
+            }
         }
+    }
+
+    private func paymentDateBinding(_ payment: PartialPayment) -> Binding<Date> {
+        Binding(
+            get: { document.paiementsPartiels.first(where: { $0.id == payment.id })?.date ?? payment.date },
+            set: { newValue in
+                guard let index = document.paiementsPartiels.firstIndex(where: { $0.id == payment.id }) else { return }
+                document.paiementsPartiels[index].date = newValue
+                saveDocument()
+            }
+        )
+    }
+
+    private func paymentAmountBinding(_ payment: PartialPayment) -> Binding<Decimal> {
+        Binding(
+            get: { document.paiementsPartiels.first(where: { $0.id == payment.id })?.montant ?? payment.montant },
+            set: { newValue in
+                guard let index = document.paiementsPartiels.firstIndex(where: { $0.id == payment.id }) else { return }
+                document.paiementsPartiels[index].montant = newValue
+                saveDocument()
+            }
+        )
     }
 
     // MARK: - Devise & Mode de paiement

--- a/Facio/Views/Documents/DocumentEditorView.swift
+++ b/Facio/Views/Documents/DocumentEditorView.swift
@@ -517,14 +517,43 @@ struct DocumentEditorView: View {
                     set: { document.dateEcheance = $0; saveDocument() }
                 ), displayedComponents: .date)
             }
-            // Date d'encaissement : rattache le CA au bon mois. Visible seulement
-            // quand la facture est payée.
-            if document.status == .payee {
+            // Date d'encaissement : rattache le CA au bon mois. Visible quand la
+            // facture est payée ou partiellement réglée.
+            if document.status == .payee || document.status == .partiel {
                 DatePicker(L10n.paymentDate(lang), selection: Binding(
                     get: { document.datePaiement ?? document.dateCreation },
                     set: { document.datePaiement = $0; saveDocument() }
                 ), displayedComponents: .date)
-                .tint(.intentSuccess)
+                .tint(document.status == .partiel ? .intentInfo : .intentSuccess)
+            }
+            // Paiement partiel : acompte encaissé saisi + reste à payer calculé.
+            if document.status == .partiel {
+                HStack(alignment: .top, spacing: FacioLayout.space24) {
+                    LabeledField(L10n.amountPaid(lang)) {
+                        HStack(spacing: FacioLayout.space8) {
+                            DecimalField(
+                                placeholder: "0",
+                                value: Binding(
+                                    get: { document.montantPaye ?? 0 },
+                                    set: { document.montantPaye = $0; saveDocument() }
+                                ),
+                                maximumFractionDigits: document.currency.maximumFractionDigits,
+                                format: dataStore.companyInfo.formatNombre
+                            )
+                            .density(.regular)
+                            .frame(maxWidth: 160)
+                            Text(document.currency.label)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    LabeledField(L10n.remainingToPay(lang)) {
+                        MoneyText(
+                            amount: document.resteAPayer,
+                            currency: document.currency,
+                            lang: dataStore.companyInfo.formatNombre
+                        )
+                    }
+                }
             }
         }
     }

--- a/Facio/Views/Documents/DocumentEditorView.swift
+++ b/Facio/Views/Documents/DocumentEditorView.swift
@@ -579,14 +579,32 @@ struct DocumentEditorView: View {
                 }
             }
 
-            Button {
-                document.paiementsPartiels.append(PartialPayment())
-                saveDocument()
-            } label: {
-                Label(L10n.addPartialPayment(lang), systemImage: "plus.circle")
+            HStack(spacing: FacioLayout.space16) {
+                Button {
+                    document.paiementsPartiels.append(PartialPayment())
+                    saveDocument()
+                } label: {
+                    Label(L10n.addPartialPayment(lang), systemImage: "plus.circle")
+                }
+                .buttonStyle(.borderless)
+                .tint(.intentInfo)
+
+                // Raccourci : une fois un premier versement saisi, régler d'un clic
+                // tout le solde restant (100 %) comme dernier versement.
+                if document.montantEncaisse > 0 && document.resteAPayer > 0 {
+                    Button(action: payRemainingBalance) {
+                        Label(
+                            L10n.payRemainingBalance(
+                                lang,
+                                amount: document.currency.formatAccounting(document.resteAPayer, lang: dataStore.companyInfo.formatNombre)
+                            ),
+                            systemImage: "checkmark.circle"
+                        )
+                    }
+                    .buttonStyle(.borderless)
+                    .tint(.intentSuccess)
+                }
             }
-            .buttonStyle(.borderless)
-            .tint(.intentInfo)
 
             Divider().padding(.vertical, FacioLayout.space4)
 
@@ -600,6 +618,20 @@ struct DocumentEditorView: View {
                 }
             }
         }
+    }
+
+    /// Règle tout le solde restant en un versement daté du jour : remplit une
+    /// ligne vide si elle existe, sinon en ajoute une.
+    private func payRemainingBalance() {
+        let reste = document.resteAPayer
+        guard reste > 0 else { return }
+        if let emptyIndex = document.paiementsPartiels.lastIndex(where: { $0.montant == 0 }) {
+            document.paiementsPartiels[emptyIndex].montant = reste
+            document.paiementsPartiels[emptyIndex].date = Date()
+        } else {
+            document.paiementsPartiels.append(PartialPayment(montant: reste, date: Date()))
+        }
+        saveDocument()
     }
 
     private func paymentDateBinding(_ payment: PartialPayment) -> Binding<Date> {

--- a/Facio/Views/Documents/DocumentFilterPanel.swift
+++ b/Facio/Views/Documents/DocumentFilterPanel.swift
@@ -10,7 +10,7 @@ enum DateFilterPreset: String, CaseIterable, Identifiable {
 /// en retard (envoyée + échéance dépassée) est « En retard » et non « Envoyée ».
 /// Chaque document tombe dans exactement une catégorie.
 enum DocumentStatusFilter: String, CaseIterable, Identifiable {
-    case brouillon, envoyee, overdue, payee, annulee
+    case brouillon, envoyee, overdue, partiel, payee, annulee
     var id: String { rawValue }
 
     static func category(of doc: Document) -> DocumentStatusFilter {
@@ -18,6 +18,7 @@ enum DocumentStatusFilter: String, CaseIterable, Identifiable {
         switch doc.status {
         case .brouillon: return .brouillon
         case .envoyee: return .envoyee
+        case .partiel: return .partiel
         case .payee: return .payee
         case .annulee: return .annulee
         }
@@ -28,6 +29,7 @@ enum DocumentStatusFilter: String, CaseIterable, Identifiable {
         case .brouillon: return DocumentStatus.brouillon.label(for: l)
         case .envoyee: return DocumentStatus.envoyee.label(for: l)
         case .overdue: return L10n.filterOverdue(l)
+        case .partiel: return DocumentStatus.partiel.label(for: l)
         case .payee: return DocumentStatus.payee.label(for: l)
         case .annulee: return DocumentStatus.annulee.label(for: l)
         }
@@ -38,6 +40,7 @@ enum DocumentStatusFilter: String, CaseIterable, Identifiable {
         case .overdue: return .intentDanger
         case .brouillon: return Color.statusColor(for: .brouillon)
         case .envoyee: return Color.statusColor(for: .envoyee)
+        case .partiel: return Color.statusColor(for: .partiel)
         case .payee: return Color.statusColor(for: .payee)
         case .annulee: return Color.statusColor(for: .annulee)
         }

--- a/Facio/Views/Documents/DocumentListView.swift
+++ b/Facio/Views/Documents/DocumentListView.swift
@@ -288,7 +288,7 @@ struct DocumentRowView: View {
                     Text(document.number)
                         .font(.headline)
                         .lineLimit(1)
-                    StatusBadge(status: document.status, isOverdue: document.isOverdue)
+                    StatusBadge(status: document.status, isOverdue: document.isOverdue, paidViaInstallments: document.isPaidViaInstallments)
                 }
 
                 HStack(spacing: 6) {

--- a/Facio/Views/Documents/DocumentListView.swift
+++ b/Facio/Views/Documents/DocumentListView.swift
@@ -74,8 +74,9 @@ struct DocumentListView: View {
         switch s {
         case .brouillon: return 0
         case .envoyee: return 1
-        case .payee: return 2
-        case .annulee: return 3
+        case .partiel: return 2
+        case .payee: return 3
+        case .annulee: return 4
         }
     }
 
@@ -318,7 +319,7 @@ struct DocumentRowView: View {
     }
 
     private var dateSummary: String {
-        if document.type == .facture && (document.status == .envoyee || document.isOverdue) {
+        if document.type == .facture && (document.status == .envoyee || document.status == .partiel || document.isOverdue) {
             return "\(L10n.dueDateLabel(lang)): \(document.dateEcheance.formattedDate(for: dateFormat))"
         }
         return document.dateCreation.formattedDate(for: dateFormat)


### PR DESCRIPTION
Closes #101.

Adds a **"Partiel" (partial payment)** invoice status with a **ledger of several dated payments**, so a deposit/acompte paid in installments is tracked clearly: each payment (date + amount), the total received, and the remaining balance.

## What it does

- **New status `Partiel`** between *Envoyée* and *Payée* — own badge (`circle.lefthalf.filled`, info/blue), filter chip, sort rank, FR/EN localization.
- **Editor — payment ledger**: when an invoice is *Partiel*, a clean list of payments appears, each with its **date** + **amount** and a delete button, a **+ Ajouter un paiement** button, and a live recap **Montant payé / Reste à payer** (green when settled). A first row is pre-added when you switch to *Partiel*.
- **Dashboard CA**: every payment is recognized in **its own month/year** (cash-basis), so an acompte in March and a balance in June land in the right months. The remaining balance feeds **Montant en attente**.
- **Clients**: the per-client *paid* total includes the received installments.
- **PDF**: *Montant payé* / *Reste à payer* under the Total TTC for partial invoices.

## Model / correctness

- `Document.paiementsPartiels: [PartialPayment]` (id + amount + date); backwards-compatible Codable (`decodeOrDefault` → `[]`).
- A single capped source of truth for cash recognition (`datedCashContributions`): **cumulative cap at `[0, TTC]`** in chronological order, so over-entry never inflates revenue and zero/negative entries are ignored. `montantEncaisse + resteAPayer == TTC` always.
- **Settling *Partiel* → *Payée* preserves the dated ledger** (records the remaining balance as a final payment dated today) — prior-month revenue is never retroactively moved.
- Editor list is rendered in stable insertion order (editing a date no longer reorders rows mid-edit).

## Tests

- `swift build` ✅
- Regression suite: **103 passed, 0 failed** (`swift run Facio --run-regressions`), including: *partial status computes reste à payer* (multi-payment, over-payment cap, settle-keeps-ledger) and *partial payments bucket cash by payment date*, plus the old-payload decode case.

Two rounds of adversarial multi-agent review (correctness / accounting / conventions / SwiftUI bindings) were run on the diffs; all confirmed findings — including settle-time data loss, CA clamping, and row reordering — are fixed in this branch.
